### PR TITLE
feat: add Vue.js component support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,10 @@ A Django based web interface for exploring data from the `baseball-data-lab` lib
 3. Visit `http://localhost:8000/` to see the home page displaying information from `baseball-data-lab`.
 
 This project is a minimal scaffold and is intended to grow with additional views and data presentations over time.
+
+## Frontend
+
+Vue.js is available for building interactive components. The home page shows a
+minimal example component mounted from `stats/static/stats/app.js` and loaded
+from the Vue CDN. Additional Vue components can be created in that directory
+and referenced from Django templates using the `{% static %}` tag.

--- a/stats/static/stats/app.js
+++ b/stats/static/stats/app.js
@@ -1,0 +1,7 @@
+const HelloComponent = {
+    template: `<div class="vue-message">This is rendered by a Vue component.</div>`
+};
+
+const app = Vue.createApp({});
+app.component('hello-component', HelloComponent);
+app.mount('#vue-app');

--- a/stats/templates/stats/home.html
+++ b/stats/templates/stats/home.html
@@ -1,3 +1,4 @@
+{% load static %}
 <!DOCTYPE html>
 <html>
 <head>
@@ -10,5 +11,10 @@
     {% if data %}
         <pre>{{ data }}</pre>
     {% endif %}
+    <div id="vue-app">
+        <hello-component></hello-component>
+    </div>
+    <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
+    <script src="{% static 'stats/app.js' %}"></script>
 </body>
 </html>

--- a/stats/tests.py
+++ b/stats/tests.py
@@ -5,3 +5,4 @@ class HomeViewTests(TestCase):
         client = Client()
         response = client.get('/')
         self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'hello-component')


### PR DESCRIPTION
## Summary
- document Vue.js integration and static asset usage
- mount a simple Vue component on the home page
- test for Vue component presence in the rendered home view

## Testing
- ⚠️ `python manage.py test` *(missing Django dependency)*


------
https://chatgpt.com/codex/tasks/task_e_68a3768e963c8326866a293ef78e0951