### PR TITLE
Install baseball-data-lab from GitHub

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Django>=4.2
--e ../baseball-data-lab
+git+https://github.com/timothyf/baseball-data-lab.git@main#egg=baseball-data-lab


### PR DESCRIPTION
## Summary
- Install `baseball-data-lab` via its GitHub repository instead of a local path

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a381e59e448326817ab642b6c4d40b