### PR TITLE
feat: show baseball-data-lab import errors

### DIFF
--- a/stats/views.py
+++ b/stats/views.py
@@ -2,8 +2,10 @@ from django.shortcuts import render
 
 try:
     import baseball_data_lab as bdl
-except Exception:  # pragma: no cover - handles missing dependency
+    _bdl_error = None
+except Exception as exc:  # pragma: no cover - handles missing dependency
     bdl = None
+    _bdl_error = str(exc)
 
 def home(request):
     """Simple view that demonstrates integration with baseball-data-lab."""
@@ -16,4 +18,6 @@ def home(request):
             data = sample
         except Exception as exc:  # pragma: no cover - defensive
             data = [f"Error fetching data: {exc}"]
+    elif _bdl_error:
+        message = f"baseball-data-lab import error: {_bdl_error}"
     return render(request, 'stats/home.html', {'message': message, 'data': data})


### PR DESCRIPTION
## Summary
- surface import errors from `baseball-data-lab` so missing modules are visible on the homepage

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a39c2480c083269008f41dabb61669