### PR TITLE
Display today's MLB schedule on home page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,9 @@
 Django>=4.2
 git+https://github.com/timothyf/baseball-data-lab.git@main#egg=baseball-data-lab
+MLB-StatsAPI
+mplcursors
+pandas
+pillow
+pybaseball
+requests
+seaborn

--- a/stats/templates/stats/home.html
+++ b/stats/templates/stats/home.html
@@ -8,8 +8,15 @@
 <body>
     <h1>Baseball Data Lab Web</h1>
     <p>{{ message }}</p>
-    {% if data %}
-        <pre>{{ data }}</pre>
+    {% if schedule %}
+        <h2>Today's Schedule</h2>
+        <ul>
+        {% for day in schedule %}
+            {% for game in day.games %}
+                <li>{{ game.teams.away.team.name }} at {{ game.teams.home.team.name }} - {{ game.gameDate }}</li>
+            {% endfor %}
+        {% endfor %}
+        </ul>
     {% endif %}
     <div id="vue-app">
         <hello-component></hello-component>

--- a/stats/tests.py
+++ b/stats/tests.py
@@ -1,8 +1,27 @@
+from unittest.mock import patch
 from django.test import TestCase, Client
 
+
 class HomeViewTests(TestCase):
-    def test_home_view(self):
+    @patch('stats.views.UnifiedDataClient')
+    def test_home_view(self, mock_client_cls):
+        mock_client = mock_client_cls.return_value
+        mock_client.get_schedule_for_date_range.return_value = [
+            {
+                'games': [
+                    {
+                        'gameDate': '2025-08-18T18:20:00Z',
+                        'teams': {
+                            'away': {'team': {'name': 'Away Team'}},
+                            'home': {'team': {'name': 'Home Team'}},
+                        },
+                    }
+                ]
+            }
+        ]
         client = Client()
         response = client.get('/')
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, 'hello-component')
+        self.assertContains(response, "Today's Schedule")
+        self.assertContains(response, 'Away Team')
+        self.assertContains(response, 'Home Team')

--- a/stats/views.py
+++ b/stats/views.py
@@ -1,23 +1,30 @@
+from datetime import date
 from django.shortcuts import render
 
 try:
-    import baseball_data_lab as bdl
+    from baseball_data_lab.apis.unified_data_client import UnifiedDataClient
     _bdl_error = None
 except Exception as exc:  # pragma: no cover - handles missing dependency
-    bdl = None
+    UnifiedDataClient = None
     _bdl_error = str(exc)
 
+
 def home(request):
-    """Simple view that demonstrates integration with baseball-data-lab."""
+    """Home page displaying today's MLB schedule."""
     message = "baseball-data-lab library is not installed."
-    data = None
-    if bdl is not None:
-        message = f"Using baseball-data-lab version {getattr(bdl, '__version__', 'unknown')}"
+    schedule = None
+    if UnifiedDataClient is not None:
+        message = "Using baseball-data-lab UnifiedDataClient"
         try:
-            sample = getattr(bdl, 'get_sample_data', lambda: [])()
-            data = sample
+            client = UnifiedDataClient()
+            today = date.today()
+            schedule = client.get_schedule_for_date_range(today, today)
         except Exception as exc:  # pragma: no cover - defensive
-            data = [f"Error fetching data: {exc}"]
+            schedule = [f"Error fetching schedule: {exc}"]
     elif _bdl_error:
         message = f"baseball-data-lab import error: {_bdl_error}"
-    return render(request, 'stats/home.html', {'message': message, 'data': data})
+    context = {
+        'message': message,
+        'schedule': schedule,
+    }
+    return render(request, 'stats/home.html', context)


### PR DESCRIPTION
## Summary
- Fetch today's MLB schedule using baseball-data-lab `UnifiedDataClient`
- Render schedule on the home page under "Today's Schedule"
- Add required dependencies and tests for schedule display

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a3aa02a4388326b973fc371526ac74