### PR TITLE
fix: correct frontend bundle reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This project is a minimal scaffold and is intended to grow with additional views
 ## Frontend
 
 Vue components live in the `frontend/` directory and are bundled with Vite into
-`frontend/dist/app.js`. During development you can run:
+`frontend/dist/main.js`. During development you can run:
 
 ```bash
 npm run dev

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -10,6 +10,6 @@
     <p>{{ message }}</p>
     {{ schedule|json_script:"schedule-data" }}
     <div id="vue-app"></div>
-    <script src="{% static 'app.js' %}"></script>
+    <script src="{% static 'main.js' %}"></script>
 </body>
 </html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,7 +8,7 @@ export default defineConfig({
     lib: {
       entry: resolve(__dirname, 'frontend/main.js'),
       name: 'App',
-      fileName: () => 'app.js',
+      fileName: () => 'main.js',
       formats: ['iife']
     },
     outDir: 'frontend/dist',


### PR DESCRIPTION
## Summary
- reference Vite bundle as `main.js`
- update Vite config to emit `main.js`
- adjust documentation accordingly

## Testing
- `npm run build`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a3b922c9fc8326b70879c88b8b7ba7