### PR TITLE
Define NODE_ENV during Vite build

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,10 @@ import { resolve } from 'path';
 
 export default defineConfig({
   plugins: [vue()],
+  define: {
+    // Avoid runtime ReferenceError by replacing process.env.NODE_ENV at build time
+    'process.env.NODE_ENV': JSON.stringify('production')
+  },
   build: {
     lib: {
       entry: resolve(__dirname, 'frontend/main.js'),


### PR DESCRIPTION
## Summary
- replace process.env.NODE_ENV during Vite build to avoid runtime ReferenceError

## Testing
- `npm run build`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a3bb9adb20832685945ef8a5302d10