### PR TITLE
Add Procfile for Foreman dev environment

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+backend: cd backend && python manage.py runserver
+frontend: cd frontend && npm run dev

--- a/README.md
+++ b/README.md
@@ -8,19 +8,23 @@ A Django based web interface for exploring data from the `baseball-data-lab` lib
    ```bash
    pip install -r backend/requirements.txt
    ```
-2. Install frontend dependencies and build the bundled assets:
+2. Install frontend dependencies:
    ```bash
    cd frontend
    npm install
-   npm run build
+   cd ..
    ```
-3. Run database migrations and start the development server:
+3. Run database migrations:
    ```bash
-   cd ../backend
+   cd backend
    python manage.py migrate
-   python manage.py runserver
+   cd ..
    ```
-4. Visit `http://localhost:8000/` to see the home page displaying information from `baseball-data-lab`.
+4. Start the frontend and backend development servers together:
+   ```bash
+   foreman start -j Procfile.dev
+   ```
+5. Visit `http://localhost:8000/` to see the home page displaying information from `baseball-data-lab`.
 
 This project is a minimal scaffold and is intended to grow with additional views and data presentations over time.
 


### PR DESCRIPTION
## Summary
- add Procfile.dev to launch Django and Vite dev servers with Foreman
- document using Foreman to start both dev servers

## Testing
- `npx --yes foreman start -j Procfile.dev`

------
https://chatgpt.com/codex/tasks/task_e_68a3e350c5f483268214e3c4c58ee630