### PR TITLE
Use Vite dev server for Django development

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,12 @@ This project is a minimal scaffold and is intended to grow with additional views
 ## Frontend
 
 Vue components live in the `frontend/` directory and are bundled with Vite into
-`backend/static/frontend/main.js`. During development you can run:
+`backend/static/frontend/main.js` for production. During development you can run:
 
 ```bash
 npm run dev
 ```
 
-to start a development server with hot-reloading. The compiled asset is
-referenced from Django templates using the `{% static %}` tag.
+to start a development server with hot-reloading. When `DEBUG` is enabled,
+the Django template pulls scripts from `http://localhost:5173` automatically.
+In production, the prebuilt asset is referenced using the `{% static %}` tag.

--- a/backend/apps/web/templates/web/index.html
+++ b/backend/apps/web/templates/web/index.html
@@ -10,6 +10,11 @@
     <p>{{ message }}</p>
     {{ schedule|json_script:"schedule-data" }}
     <div id="vue-app"></div>
+    {% if debug %}
+    <script type="module" src="http://localhost:5173/@vite/client"></script>
+    <script type="module" src="http://localhost:5173/src/main.js"></script>
+    {% else %}
     <script src="{% static 'frontend/main.js' %}"></script>
+    {% endif %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Load scripts from the Vite dev server when Django runs in DEBUG mode
- Update docs to explain automatic use of the dev server and production bundle

## Testing
- `cd backend && python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a3e5d1e490832681d3027959427520