### PR TITLE
Display team logos in schedule view

### DIFF
--- a/backend/apps/web/tests.py
+++ b/backend/apps/web/tests.py
@@ -12,13 +12,14 @@ class HomeViewTests(TestCase):
                     {
                         'gameDate': '2025-08-18T18:20:00Z',
                         'teams': {
-                            'away': {'team': {'name': 'Away Team'}},
-                            'home': {'team': {'name': 'Home Team'}},
+                            'away': {'team': {'name': 'Away Team', 'id': 1}},
+                            'home': {'team': {'name': 'Home Team', 'id': 2}},
                         },
                     }
                 ]
             }
         ]
+        mock_client.get_team_spot_url.return_value = 'logo-url'
         client = Client()
         response = client.get('/')
         self.assertEqual(response.status_code, 200)
@@ -26,3 +27,4 @@ class HomeViewTests(TestCase):
         self.assertContains(response, 'id="vue-app"')
         self.assertContains(response, 'Away Team')
         self.assertContains(response, 'Home Team')
+        self.assertContains(response, 'logo-url')

--- a/backend/apps/web/views.py
+++ b/backend/apps/web/views.py
@@ -27,6 +27,24 @@ def home(request):
             except Exception:  # Fallback if zoneinfo unavailable
                 today = date.today()
             schedule = client.get_schedule_for_date_range(today, today)
+
+            # Attach team logo URLs for home and away teams
+            try:
+                for day in schedule:
+                    for game in day.get("games", []):
+                        teams = game.get("teams", {})
+                        for side in ("home", "away"):
+                            team = teams.get(side, {}).get("team")
+                            team_id = team.get("id") if team else None
+                            if team_id:
+                                try:
+                                    team["logo_url"] = client.get_team_spot_url(
+                                        team_id, 32
+                                    )
+                                except Exception:  # pragma: no cover - defensive
+                                    team["logo_url"] = None
+            except Exception:  # pragma: no cover - defensive
+                pass
         except Exception as exc:  # pragma: no cover - defensive
             schedule = [f"Error fetching schedule: {exc}"]
     elif _bdl_error:

--- a/frontend/src/views/ScheduleView.vue
+++ b/frontend/src/views/ScheduleView.vue
@@ -19,9 +19,15 @@
               boxShadow:'0 1px 2px rgba(0,0,0,0.04)'
             }">
           <div class="game-teams">
-            <span class="team-chip away" style="display:inline-block;padding:2px 6px;margin-right:4px;background:#ffffff;">{{ teamAbbrev(game.teams.away.team) }}</span>
+            <span class="team-chip away" style="display:inline-flex;align-items:center;padding:2px 6px;margin-right:4px;background:#ffffff;">
+              <img v-if="game.teams.away.team.logo_url" :src="game.teams.away.team.logo_url" alt="" class="team-logo" />
+              {{ teamAbbrev(game.teams.away.team) }}
+            </span>
             <span style="padding:0 4px;opacity:.6;">@</span>
-            <span class="team-chip home" style="display:inline-block;padding:2px 6px;margin-left:4px;background:#ffffff;">{{ teamAbbrev(game.teams.home.team) }}</span>
+            <span class="team-chip home" style="display:inline-flex;align-items:center;padding:2px 6px;margin-left:4px;background:#ffffff;">
+              <img v-if="game.teams.home.team.logo_url" :src="game.teams.home.team.logo_url" alt="" class="team-logo" />
+              {{ teamAbbrev(game.teams.home.team) }}
+            </span>
           </div>
           <div class="game-time">{{ gameTime(game) }}</div>
           <div class="game-broadcasts" v-if="game.broadcasts && game.broadcasts.length">
@@ -134,6 +140,12 @@ function shortName(name) {
 .team-name {
   font-weight: bold;
   color: #333;
-} 
+}
+
+.team-logo {
+  width: 20px;
+  height: 20px;
+  margin-right: 4px;
+}
 </style>
 


### PR DESCRIPTION
## Summary
- Fetch team logo URLs via UnifiedDataClient and embed them in schedule data
- Show home and away team logos alongside abbreviations in the schedule view
- Add test coverage for logo URL retrieval

## Testing
- `cd backend && python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a3f79468b08326a512639781ca4769