### PR TITLE
Show final scores in schedule display

### DIFF
--- a/frontend/src/views/ScheduleView.vue
+++ b/frontend/src/views/ScheduleView.vue
@@ -30,6 +30,9 @@
             </span>
           </div>
           <div class="game-time">{{ gameTime(game) }}</div>
+          <div class="game-score" v-if="game.status?.detailedState === 'Final'">
+            {{ game.teams.away.score }} - {{ game.teams.home.score }}
+          </div>
           <div class="game-broadcasts" v-if="game.broadcasts && game.broadcasts.length">
             {{ game.broadcasts.map(b => b.callSign || b.name).join(', ') }}
             </div>
@@ -122,6 +125,12 @@ function shortName(name) {
 
 .game-time {
   width: 80px;
+}
+
+.game-score {
+  width: 60px;
+  font-weight: 600;
+  text-align: center;
 }
 
 .game-broadcasts {


### PR DESCRIPTION
## Summary
- Display final game scores in the schedule when games are completed
- Add styles for the new score column

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3fc1c27bc832686cdbeecd718507e