### PR TITLE
Add top menu bar with navigation links

### DIFF
--- a/backend/apps/web/templates/web/base.html
+++ b/backend/apps/web/templates/web/base.html
@@ -1,0 +1,32 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>{% block title %}Baseball Data Lab Web{% endblock %}</title>
+    <style>
+        .top-nav {
+            background-color: #007bff;
+            padding: 10px;
+        }
+        .top-nav a {
+            color: white;
+            margin-right: 15px;
+            text-decoration: none;
+        }
+        .top-nav a:hover {
+            text-decoration: underline;
+        }
+    </style>
+    {% block head %}{% endblock %}
+</head>
+<body>
+    <nav class="top-nav">
+        <a href="{% url 'home' %}">Home</a>
+        <a href="{% url 'schedule' %}">Schedule</a>
+        <a href="{% url 'standings' %}">Standings</a>
+        <a href="{% url 'players' %}">Players</a>
+    </nav>
+    {% block content %}{% endblock %}
+</body>
+</html>

--- a/backend/apps/web/templates/web/index.html
+++ b/backend/apps/web/templates/web/index.html
@@ -1,24 +1,18 @@
+{% extends "web/base.html" %}
 {% load static %}
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8" />
-    <title>Baseball Data Lab Web</title>
-</head>
-<body>
-    <h1>Baseball Data Lab Web</h1>
-    <p>{{ message }}</p>
-    {{ schedule|json_script:"schedule-data" }}
-    <div id="vue-app"></div>
 
-    {% if DJANGO_USE_VITE_DEV %}
-        <!-- Vite dev server with HMR -->
-        <script type="module" src="http://localhost:5173/@vite/client"></script>
-        <script type="module" src="http://localhost:5173/src/main.js"></script>
-    {% else %}
-        <!-- Built static bundle -->
-        <script src="{% static 'frontend/main.js' %}"></script>
-    {% endif %}
-</body>
-</html>
+{% block content %}
+<h1>Baseball Data Lab Web</h1>
+<p>{{ message }}</p>
+{{ schedule|json_script:"schedule-data" }}
+<div id="vue-app"></div>
 
+{% if DJANGO_USE_VITE_DEV %}
+    <!-- Vite dev server with HMR -->
+    <script type="module" src="http://localhost:5173/@vite/client"></script>
+    <script type="module" src="http://localhost:5173/src/main.js"></script>
+{% else %}
+    <!-- Built static bundle -->
+    <script src="{% static 'frontend/main.js' %}"></script>
+{% endif %}
+{% endblock %}

--- a/backend/apps/web/templates/web/players.html
+++ b/backend/apps/web/templates/web/players.html
@@ -1,0 +1,6 @@
+{% extends "web/base.html" %}
+{% block title %}Players - Baseball Data Lab Web{% endblock %}
+{% block content %}
+<h1>Players</h1>
+<p>Players page content coming soon.</p>
+{% endblock %}

--- a/backend/apps/web/templates/web/schedule.html
+++ b/backend/apps/web/templates/web/schedule.html
@@ -1,0 +1,6 @@
+{% extends "web/base.html" %}
+{% block title %}Schedule - Baseball Data Lab Web{% endblock %}
+{% block content %}
+<h1>Schedule</h1>
+<p>Schedule page content coming soon.</p>
+{% endblock %}

--- a/backend/apps/web/templates/web/standings.html
+++ b/backend/apps/web/templates/web/standings.html
@@ -1,0 +1,6 @@
+{% extends "web/base.html" %}
+{% block title %}Standings - Baseball Data Lab Web{% endblock %}
+{% block content %}
+<h1>Standings</h1>
+<p>Standings page content coming soon.</p>
+{% endblock %}

--- a/backend/apps/web/urls.py
+++ b/backend/apps/web/urls.py
@@ -3,4 +3,7 @@ from . import views
 
 urlpatterns = [
     path('', views.home, name='home'),
+    path('schedule/', views.schedule, name='schedule'),
+    path('standings/', views.standings, name='standings'),
+    path('players/', views.players, name='players'),
 ]

--- a/backend/apps/web/views.py
+++ b/backend/apps/web/views.py
@@ -54,3 +54,12 @@ def home(request):
         'schedule': schedule,
     }
     return render(request, 'web/index.html', context)
+
+def schedule(request):
+    return render(request, 'web/schedule.html')
+
+def standings(request):
+    return render(request, 'web/standings.html')
+
+def players(request):
+    return render(request, 'web/players.html')


### PR DESCRIPTION
## Summary
- Create base template with blue navigation bar linking to Home, Schedule, Standings, and Players pages
- Add placeholder templates and view functions for Schedule, Standings, and Players
- Wire new views into URL configuration

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a49ab1ca788326b9622ac4dc7898f2