### PR TITLE
Add standings view and API

### DIFF
--- a/backend/apps/api/tests.py
+++ b/backend/apps/api/tests.py
@@ -29,3 +29,27 @@ class ScheduleApiTests(TestCase):
         game = data[0]['games'][0]
         self.assertEqual(game['teams']['home']['team']['logo_url'], 'logo-url')
         self.assertEqual(game['teams']['away']['team']['logo_url'], 'logo-url')
+
+
+class StandingsApiTests(TestCase):
+    @patch('apps.api.views.UnifiedDataClient')
+    def test_standings_endpoint(self, mock_client_cls):
+        mock_client = mock_client_cls.return_value
+        mock_client.get_standings_data.return_value = {
+            'records': [
+                {
+                    'league': {'name': 'American League'},
+                    'division': {'name': 'East'},
+                    'teamRecords': [
+                        {'team': {'id': 1, 'name': 'Team A'}, 'wins': 10, 'losses': 5},
+                        {'team': {'id': 2, 'name': 'Team B'}, 'wins': 8, 'losses': 7},
+                    ],
+                }
+            ]
+        }
+        client = Client()
+        response = client.get('/api/standings/')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn('records', data)
+        self.assertEqual(len(data['records'][0]['teamRecords']), 2)

--- a/backend/apps/api/urls.py
+++ b/backend/apps/api/urls.py
@@ -3,4 +3,5 @@ from . import views
 
 urlpatterns = [
     path('schedule/', views.schedule, name='api-schedule'),
+    path('standings/', views.standings, name='api-standings'),
 ]

--- a/backend/apps/api/views.py
+++ b/backend/apps/api/views.py
@@ -39,3 +39,17 @@ def schedule(request):
         return JsonResponse(schedule, safe=False)
     except Exception as exc:  # pragma: no cover - defensive
         return JsonResponse({'error': str(exc)}, status=500)
+
+
+@require_GET
+def standings(request):
+    """Return standings data for the current season."""
+    if UnifiedDataClient is None:
+        return JsonResponse({'error': 'baseball-data-lab library is not installed'}, status=500)
+    try:
+        client = UnifiedDataClient()
+        season = datetime.now().year
+        data = client.get_standings_data(season=season, league_ids="103,104")
+        return JsonResponse(data, safe=False)
+    except Exception as exc:  # pragma: no cover - defensive
+        return JsonResponse({'error': str(exc)}, status=500)

--- a/backend/apps/web/templates/web/standings.html
+++ b/backend/apps/web/templates/web/standings.html
@@ -1,6 +1,13 @@
 {% extends "web/base.html" %}
+{% load static %}
 {% block title %}Standings - Baseball Data Lab Web{% endblock %}
 {% block content %}
 <h1>Standings</h1>
-<p>Standings page content coming soon.</p>
+<div id="vue-app"></div>
+{% if DJANGO_USE_VITE_DEV %}
+    <script type="module" src="http://localhost:5173/@vite/client"></script>
+    <script type="module" src="http://localhost:5173/src/main.js"></script>
+{% else %}
+    <script src="{% static 'frontend/main.js' %}"></script>
+{% endif %}
 {% endblock %}

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,11 +1,17 @@
 import { createRouter, createWebHistory } from 'vue-router';
 import ScheduleView from '../views/ScheduleView.vue';
+import StandingsView from '../views/StandingsView.vue';
 
 const routes = [
   {
     path: '/',
     name: 'Schedule',
     component: ScheduleView
+  },
+  {
+    path: '/standings',
+    name: 'Standings',
+    component: StandingsView
   }
 ];
 

--- a/frontend/src/store/standings.js
+++ b/frontend/src/store/standings.js
@@ -1,0 +1,5 @@
+import { reactive } from 'vue';
+
+export const standingsStore = reactive({
+  standings: []
+});

--- a/frontend/src/views/StandingsView.vue
+++ b/frontend/src/views/StandingsView.vue
@@ -1,0 +1,58 @@
+<template>
+  <div v-if="standingsStore.standings.length">
+    <div v-for="(record, index) in standingsStore.standings" :key="index" class="division">
+      <h2>{{ record.division?.name }}</h2>
+      <table class="standings-table">
+        <thead>
+          <tr>
+            <th>Team</th>
+            <th>W</th>
+            <th>L</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="teamRecord in record.teamRecords" :key="teamRecord.team.id">
+            <td>{{ teamRecord.team.name }}</td>
+            <td>{{ teamRecord.wins }}</td>
+            <td>{{ teamRecord.losses }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div v-else>
+    <p>No standings data available.</p>
+  </div>
+</template>
+
+<script setup>
+import { onMounted } from 'vue';
+import { standingsStore } from '../store/standings';
+
+async function fetchStandings() {
+  const resp = await fetch('/api/standings/');
+  const data = await resp.json();
+  standingsStore.standings = data.records || data;
+}
+
+onMounted(() => {
+  fetchStandings();
+});
+</script>
+
+<style scoped>
+.standings-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1rem;
+}
+.standings-table th,
+.standings-table td {
+  border: 1px solid #e2e8f0;
+  padding: 4px 8px;
+  text-align: left;
+}
+.division {
+  margin-bottom: 2rem;
+}
+</style>


### PR DESCRIPTION
## Summary
- serve standings data via new `/api/standings/` endpoint using baseball-data-lab
- mount Vue app on Standings page and add router entry
- create Vue standings view and store to display league standings

## Testing
- `python manage.py test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a4a5debe78832697c44802ce7b7a0a