### PR TITLE
Add Teams view scaffold and navigation link

### DIFF
--- a/backend/apps/web/templates/web/base.html
+++ b/backend/apps/web/templates/web/base.html
@@ -25,6 +25,7 @@
         <a href="{% url 'home' %}">Home</a>
         <a href="{% url 'schedule' %}">Schedule</a>
         <a href="{% url 'standings' %}">Standings</a>
+        <a href="{% url 'teams' %}">Teams</a>
         <a href="{% url 'players' %}">Players</a>
     </nav>
     {% block content %}{% endblock %}

--- a/backend/apps/web/templates/web/teams.html
+++ b/backend/apps/web/templates/web/teams.html
@@ -1,0 +1,13 @@
+{% extends "web/base.html" %}
+{% load static %}
+{% block title %}Teams - Baseball Data Lab Web{% endblock %}
+{% block content %}
+<h1>Teams</h1>
+<div id="vue-app"></div>
+{% if DJANGO_USE_VITE_DEV %}
+    <script type="module" src="http://localhost:5173/@vite/client"></script>
+    <script type="module" src="http://localhost:5173/src/main.js"></script>
+{% else %}
+    <script src="{% static 'frontend/main.js' %}"></script>
+{% endif %}
+{% endblock %}

--- a/backend/apps/web/urls.py
+++ b/backend/apps/web/urls.py
@@ -5,5 +5,6 @@ urlpatterns = [
     path('', views.home, name='home'),
     path('schedule/', views.schedule, name='schedule'),
     path('standings/', views.standings, name='standings'),
+    path('teams/', views.teams, name='teams'),
     path('players/', views.players, name='players'),
 ]

--- a/backend/apps/web/views.py
+++ b/backend/apps/web/views.py
@@ -61,5 +61,8 @@ def schedule(request):
 def standings(request):
     return render(request, 'web/standings.html')
 
+def teams(request):
+    return render(request, 'web/teams.html')
+
 def players(request):
     return render(request, 'web/players.html')

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router';
 import ScheduleView from '../views/ScheduleView.vue';
 import StandingsView from '../views/StandingsView.vue';
+import TeamsView from '../views/TeamsView.vue';
 
 const routes = [
   {
@@ -12,6 +13,11 @@ const routes = [
     path: '/standings',
     name: 'Standings',
     component: StandingsView
+  },
+  {
+    path: '/teams',
+    name: 'Teams',
+    component: TeamsView
   }
 ];
 

--- a/frontend/src/store/teams.js
+++ b/frontend/src/store/teams.js
@@ -1,0 +1,5 @@
+import { reactive } from 'vue';
+
+export const teamsStore = reactive({
+  teams: []
+});

--- a/frontend/src/views/TeamsView.vue
+++ b/frontend/src/views/TeamsView.vue
@@ -1,0 +1,10 @@
+<template>
+  <div>
+    <h1>Teams</h1>
+    <p>Teams view content coming soon.</p>
+  </div>
+</template>
+
+<script setup>
+import { teamsStore } from '../store/teams';
+</script>


### PR DESCRIPTION
## Summary
- add Teams link to navigation bar
- scaffold Teams Django template and view
- create Teams Vue view, store, and router entry

## Testing
- `cd backend && python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a4b93fb5488326bb2659c674d52426