### PR TITLE
Highlight active and hovered items in top menu

### DIFF
--- a/backend/apps/web/templates/web/base.html
+++ b/backend/apps/web/templates/web/base.html
@@ -13,20 +13,26 @@
             color: white;
             margin-right: 15px;
             text-decoration: none;
+            padding: 5px 10px;
+            border-radius: 4px;
         }
-        .top-nav a:hover {
-            text-decoration: underline;
+        .top-nav a:hover,
+        .top-nav a.active {
+            background-color: #0056b3;
+        }
+        .top-nav a.active {
+            font-weight: bold;
         }
     </style>
     {% block head %}{% endblock %}
 </head>
 <body>
     <nav class="top-nav">
-        <a href="{% url 'home' %}">Home</a>
-        <a href="{% url 'schedule' %}">Schedule</a>
-        <a href="{% url 'standings' %}">Standings</a>
-        <a href="{% url 'teams' %}">Teams</a>
-        <a href="{% url 'players' %}">Players</a>
+        <a href="{% url 'home' %}" class="{% if request.resolver_match.url_name == 'home' %}active{% endif %}">Home</a>
+        <a href="{% url 'schedule' %}" class="{% if request.resolver_match.url_name == 'schedule' %}active{% endif %}">Schedule</a>
+        <a href="{% url 'standings' %}" class="{% if request.resolver_match.url_name == 'standings' %}active{% endif %}">Standings</a>
+        <a href="{% url 'teams' %}" class="{% if request.resolver_match.url_name == 'teams' %}active{% endif %}">Teams</a>
+        <a href="{% url 'players' %}" class="{% if request.resolver_match.url_name == 'players' %}active{% endif %}">Players</a>
     </nav>
     {% block content %}{% endblock %}
 </body>


### PR DESCRIPTION
## Summary
- Highlight top menu links on hover and when active
- Bold and darken the active page link for clarity

## Testing
- `python manage.py test` *(fails: Couldn't find 'schedule-data' in the response)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f65025e883268b7cef485621ed0d