### PR TITLE
Use Aura theme for PrimeVue components

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@primevue/themes": "^4.3.7",
         "chart.js": "^4.5.0",
         "primeicons": "^7.0.0",
         "primevue": "^4.3.7",
@@ -541,6 +542,15 @@
         "@primeuix/styled": "^0.7.2"
       }
     },
+    "node_modules/@primeuix/themes": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@primeuix/themes/-/themes-1.2.3.tgz",
+      "integrity": "sha512-GLAU2h6lhgln2w10EQalUQlgwbgQ0xZoIOLMNGfIvqU4O09L282P7rwKCKQksvAGAFt1GoO/Q1NgBSxnttr7iA==",
+      "license": "MIT",
+      "dependencies": {
+        "@primeuix/styled": "^0.7.2"
+      }
+    },
     "node_modules/@primeuix/utils": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/@primeuix/utils/-/utils-0.6.1.tgz",
@@ -574,6 +584,19 @@
       "dependencies": {
         "@primeuix/utils": "^0.6.1",
         "@primevue/core": "4.3.7"
+      },
+      "engines": {
+        "node": ">=12.11.0"
+      }
+    },
+    "node_modules/@primevue/themes": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/@primevue/themes/-/themes-4.3.7.tgz",
+      "integrity": "sha512-Ej/3CBGpSIJFo0BJHrPa7HjyQZ8YPxQUiOuXj1tKFJkSqFxgOk52JL6aLBGdQkSnx7TjkHuHuKuk4t6SKkD5hw==",
+      "license": "MIT",
+      "dependencies": {
+        "@primeuix/styled": "^0.7.2",
+        "@primeuix/themes": "^1.2.3"
       },
       "engines": {
         "node": ">=12.11.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
+    "@primevue/themes": "^4.3.7",
     "chart.js": "^4.5.0",
     "primeicons": "^7.0.0",
     "primevue": "^4.3.7",

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3,6 +3,7 @@ import App from './App.vue';
 import router from './router';
 import { scheduleStore } from './store/schedule';
 import PrimeVue from 'primevue/config';
+import Aura from '@primevue/themes/aura';
 import 'primeicons/primeicons.css';
 
 const scheduleElement = document.getElementById('schedule-data');
@@ -12,5 +13,5 @@ scheduleStore.schedule = scheduleData;
 
 const app = createApp(App);
 app.use(router);
-app.use(PrimeVue);
+app.use(PrimeVue, { theme: { preset: Aura } });
 app.mount('#vue-app');

--- a/frontend/src/views/StandingsView.vue
+++ b/frontend/src/views/StandingsView.vue
@@ -44,6 +44,8 @@
 import { onMounted } from 'vue';
 import DataTable from 'primevue/datatable';
 import Column from 'primevue/column';
+import 'primevue/datatable/style';
+import 'primevue/column/style';
 import { standingsStore } from '../store/standings';
 
 async function fetchStandings() {


### PR DESCRIPTION
## Summary
- install @primevue/themes and configure PrimeVue to use the Aura theme
- ensure Standings table DataTable and Column components load their theme styles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4ff04acf48326a2c5ad9f8864dca6