### PR TITLE
Add PrimeVue player search

### DIFF
--- a/backend/apps/api/urls.py
+++ b/backend/apps/api/urls.py
@@ -4,4 +4,5 @@ from . import views
 urlpatterns = [
     path('schedule/', views.schedule, name='api-schedule'),
     path('standings/', views.standings, name='api-standings'),
+    path('players/', views.player_search, name='api-player-search'),
 ]

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -3,6 +3,7 @@ import HomeView from '../views/HomeView.vue';
 import ScheduleView from '../views/ScheduleView.vue';
 import StandingsView from '../views/StandingsView.vue';
 import TeamsView from '../views/TeamsView.vue';
+import PlayersView from '../views/PlayersView.vue';
 
 const routes = [
   {
@@ -24,6 +25,11 @@ const routes = [
     path: '/teams',
     name: 'Teams',
     component: TeamsView
+  },
+  {
+    path: '/players',
+    name: 'Players',
+    component: PlayersView
   }
 ];
 

--- a/frontend/src/views/PlayersView.vue
+++ b/frontend/src/views/PlayersView.vue
@@ -1,0 +1,42 @@
+<template>
+  <div>
+    <h1>Players</h1>
+    <AutoComplete
+      v-model="selectedPlayer"
+      :suggestions="suggestions"
+      @complete="searchPlayers"
+      optionLabel="name_full"
+      placeholder="Search for a player"
+    />
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import AutoComplete from 'primevue/autocomplete';
+import 'primevue/autocomplete/style';
+
+const selectedPlayer = ref(null);
+const suggestions = ref([]);
+
+async function searchPlayers(event) {
+  const query = event.query;
+  if (!query) {
+    suggestions.value = [];
+    return;
+  }
+  try {
+    const resp = await fetch(`/api/players/?q=${encodeURIComponent(query)}`);
+    if (resp.ok) {
+      suggestions.value = await resp.json();
+    } else {
+      suggestions.value = [];
+    }
+  } catch (err) {
+    suggestions.value = [];
+  }
+}
+</script>
+
+<style scoped>
+</style>


### PR DESCRIPTION
## Summary
- add API endpoint to search players by name from `player_id_infos`
- wire Players route and component with PrimeVue AutoComplete

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a54fda48b08326a837f6c853062652