### PR TITLE
Show selected player details

### DIFF
--- a/frontend/src/views/PlayersView.vue
+++ b/frontend/src/views/PlayersView.vue
@@ -8,6 +8,10 @@
       optionLabel="name_full"
       placeholder="Search for a player"
     />
+    <div v-if="selectedPlayer">
+      <p>Full Name: {{ selectedPlayer.name_full }}</p>
+      <p>Mlbam_ID: {{ selectedPlayer.key_mlbam }}</p>
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION
## Summary
- Display selected player's full name and MLBAM ID on Players page

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5527567348326a21ef6c7a4056dfb