### PR TITLE
Show full player name in search suggestions

### DIFF
--- a/frontend/src/views/PlayersView.vue
+++ b/frontend/src/views/PlayersView.vue
@@ -7,7 +7,11 @@
       @complete="searchPlayers"
       optionLabel="name_full"
       placeholder="Search for a player"
-    />
+    >
+      <template #option="{ option }">
+        <div>{{ option.name_full }}</div>
+      </template>
+    </AutoComplete>
     <div v-if="selectedPlayer">
       <p>Full Name: {{ selectedPlayer.name_full }}</p>
       <p>Mlbam_ID: {{ selectedPlayer.key_mlbam }}</p>


### PR DESCRIPTION
## Summary
- Render player name using option template in PlayersView autocomplete

## Testing
- `npm run build`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a559328a788326966a2fa2924f0876