### PR TITLE
Add team id info model and migration

### DIFF
--- a/backend/apps/api/migrations/0002_teamidinfo.py
+++ b/backend/apps/api/migrations/0002_teamidinfo.py
@@ -1,0 +1,40 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="TeamIdInfo",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("mlbam_team_id", models.IntegerField(null=True)),
+                ("abbrev", models.CharField(max_length=20, null=True)),
+                ("full_name", models.CharField(max_length=100, null=True)),
+                ("location_name", models.CharField(max_length=100, null=True)),
+                ("team_name", models.CharField(max_length=100, null=True)),
+                ("league", models.CharField(max_length=50, null=True)),
+                ("fg_team_id", models.IntegerField(null=True)),
+                ("mlbam_league_id", models.IntegerField(null=True)),
+                ("mlbam_division_id", models.IntegerField(null=True)),
+                ("bref_team_id", models.CharField(max_length=20, null=True)),
+                ("retrosheet_team_id", models.CharField(max_length=20, null=True)),
+                ("active_from", models.DateField(null=True)),
+                ("active_to", models.DateField(null=True)),
+            ],
+            options={
+                "db_table": "team_id_infos",
+            },
+        ),
+    ]

--- a/backend/apps/api/models.py
+++ b/backend/apps/api/models.py
@@ -7,3 +7,22 @@ class PlayerIdInfo(models.Model):
 
     class Meta:
         db_table = 'player_id_infos'
+
+
+class TeamIdInfo(models.Model):
+    mlbam_team_id = models.IntegerField(null=True)
+    abbrev = models.CharField(max_length=20, null=True)
+    full_name = models.CharField(max_length=100, null=True)
+    location_name = models.CharField(max_length=100, null=True)
+    team_name = models.CharField(max_length=100, null=True)
+    league = models.CharField(max_length=50, null=True)
+    fg_team_id = models.IntegerField(null=True)
+    mlbam_league_id = models.IntegerField(null=True)
+    mlbam_division_id = models.IntegerField(null=True)
+    bref_team_id = models.CharField(max_length=20, null=True)
+    retrosheet_team_id = models.CharField(max_length=20, null=True)
+    active_from = models.DateField(null=True)
+    active_to = models.DateField(null=True)
+
+    class Meta:
+        db_table = 'team_id_infos'


### PR DESCRIPTION
## Summary
- add TeamIdInfo Django model for team identifier metadata
- create migration to add team_id_infos table

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a61004670c832684e842fefddf6dea