### PR TITLE
Add PlayerView and navigation from players search

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -4,6 +4,7 @@ import ScheduleView from '../views/ScheduleView.vue';
 import StandingsView from '../views/StandingsView.vue';
 import TeamsView from '../views/TeamsView.vue';
 import PlayersView from '../views/PlayersView.vue';
+import PlayerView from '../views/PlayerView.vue';
 
 const routes = [
   {
@@ -30,6 +31,12 @@ const routes = [
     path: '/players',
     name: 'Players',
     component: PlayersView
+  },
+  {
+    path: '/player/:id',
+    name: 'Player',
+    component: PlayerView,
+    props: route => ({ id: route.params.id, name: route.query.name })
   }
 ];
 

--- a/frontend/src/views/PlayerView.vue
+++ b/frontend/src/views/PlayerView.vue
@@ -1,0 +1,17 @@
+<template>
+  <div>
+    <h1>Player</h1>
+    <p>ID: {{ id }}</p>
+    <p>Name: {{ name }}</p>
+  </div>
+</template>
+
+<script setup>
+const { id, name } = defineProps({
+  id: String,
+  name: String
+});
+</script>
+
+<style scoped>
+</style>

--- a/frontend/src/views/PlayersView.vue
+++ b/frontend/src/views/PlayersView.vue
@@ -5,6 +5,7 @@
       v-model="selectedPlayer"
       :suggestions="suggestions"
       @complete="searchPlayers"
+      @item-select="onSelect"
       optionLabel="name_full"
       placeholder="Search for a player"
     >
@@ -12,10 +13,6 @@
         <div>{{ option.name_full }}</div>
       </template>
     </AutoComplete>
-    <div v-if="selectedPlayer">
-      <p>Full Name: {{ selectedPlayer.name_full }}</p>
-      <p>Mlbam_ID: {{ selectedPlayer.key_mlbam }}</p>
-    </div>
   </div>
 </template>
 
@@ -23,9 +20,11 @@
 import { ref } from 'vue';
 import AutoComplete from 'primevue/autocomplete';
 import 'primevue/autocomplete/style';
+import { useRouter } from 'vue-router';
 
 const selectedPlayer = ref(null);
 const suggestions = ref([]);
+const router = useRouter();
 
 async function searchPlayers(event) {
   const query = event.query;
@@ -43,6 +42,15 @@ async function searchPlayers(event) {
   } catch (err) {
     suggestions.value = [];
   }
+}
+
+function onSelect(event) {
+  const player = event.value;
+  router.push({
+    name: 'Player',
+    params: { id: player.id },
+    query: { name: player.name_full }
+  });
 }
 </script>
 


### PR DESCRIPTION
## Summary
- add PlayerView for displaying selected player's ID and name
- navigate to PlayerView when user selects a player in PlayersView
- register PlayerView route

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a61cae38dc8326ac8c198f0889fbee