### PR TITLE
Display player headshots in PlayerView

### DIFF
--- a/backend/apps/api/tests.py
+++ b/backend/apps/api/tests.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 from django.test import TestCase, Client
+from django.db import connection
 
 
 class ScheduleApiTests(TestCase):
@@ -53,3 +54,24 @@ class StandingsApiTests(TestCase):
         data = response.json()
         self.assertIn('records', data)
         self.assertEqual(len(data['records'][0]['teamRecords']), 2)
+
+
+class PlayerHeadshotApiTests(TestCase):
+    @patch('apps.api.views.UnifiedDataClient')
+    def test_player_headshot_endpoint(self, mock_client_cls):
+        mock_client = mock_client_cls.return_value
+        mock_client.fetch_player_headshot.return_value = b'image-bytes'
+
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "INSERT INTO player_id_infos (id, key_mlbam, name_first, name_last) VALUES (%s, %s, %s, %s)",
+                [1, '123', 'Test', 'Player'],
+            )
+
+        client = Client()
+        response = client.get('/api/players/1/headshot/')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b'image-bytes')
+        self.assertEqual(response['Content-Type'], 'image/png')
+        mock_client.fetch_player_headshot.assert_called_once_with(123)

--- a/backend/apps/api/urls.py
+++ b/backend/apps/api/urls.py
@@ -5,4 +5,5 @@ urlpatterns = [
     path('schedule/', views.schedule, name='api-schedule'),
     path('standings/', views.standings, name='api-standings'),
     path('players/', views.player_search, name='api-player-search'),
+    path('players/<int:player_id>/headshot/', views.player_headshot, name='api-player-headshot'),
 ]

--- a/frontend/src/views/PlayerView.vue
+++ b/frontend/src/views/PlayerView.vue
@@ -1,17 +1,25 @@
 <template>
   <div>
     <h1>Player</h1>
+    <img v-if="headshotSrc" :src="headshotSrc" alt="Player headshot" />
     <p>ID: {{ id }}</p>
     <p>Name: {{ name }}</p>
   </div>
 </template>
 
 <script setup>
+import { computed } from 'vue';
+
 const { id, name } = defineProps({
   id: String,
   name: String
 });
+
+const headshotSrc = computed(() => `/api/players/${id}/headshot/`);
 </script>
 
 <style scoped>
+img {
+  max-width: 200px;
+}
 </style>


### PR DESCRIPTION
## Summary
- Serve player headshots through a new API endpoint backed by UnifiedDataClient
- Render the fetched headshot on PlayerView
- Test new player headshot endpoint

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a6215b8c90832687c22a10888e444a