### PR TITLE
fix: remove unused templates directory

### DIFF
--- a/backend/baseball_data_lab_web/settings/base.py
+++ b/backend/baseball_data_lab_web/settings/base.py
@@ -35,7 +35,7 @@ ROOT_URLCONF = 'baseball_data_lab_web.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [BASE_DIR / 'templates'],
+        'DIRS': [],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [


### PR DESCRIPTION
## Summary
- drop non-existent project-level templates path from settings

## Testing
- `python backend/manage.py test`
- `python backend/manage.py shell -c "from django.template.loader import get_template; get_template('web/index.html'); print('loaded')"`


------
https://chatgpt.com/codex/tasks/task_e_68a62caeae648326b106ea8f68d3e57e