### PR TITLE
Add Api app configuration

### DIFF
--- a/backend/apps/api/apps.py
+++ b/backend/apps/api/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class ApiConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'apps.api'

--- a/backend/baseball_data_lab_web/settings/base.py
+++ b/backend/baseball_data_lab_web/settings/base.py
@@ -17,7 +17,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'apps.web',
-    'apps.api',
+    'apps.api.apps.ApiConfig',
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
## Summary
- configure API app with dedicated AppConfig
- reference ApiConfig in Django settings

## Testing
- `python backend/manage.py makemigrations --check --dry-run`
- `python backend/manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a62cbe37108326b62de80a2cb11763