### PR TITLE
Use ORM for player search and add tests

### DIFF
--- a/backend/apps/api/models.py
+++ b/backend/apps/api/models.py
@@ -1,9 +1,28 @@
 from django.db import models
+from django.db.models import F, Value
+from django.db.models.functions import Concat
 
 
 class PlayerIdInfo(models.Model):
-    source = models.CharField(max_length=100)
-    external_id = models.CharField(max_length=100)
+    """Player identification information sourced from multiple providers."""
+
+    key_person = models.CharField(max_length=20, null=True)
+    key_uuid = models.CharField(max_length=40, null=True)
+    key_mlbam = models.CharField(max_length=20, null=True)
+    key_retro = models.CharField(max_length=20, null=True)
+    key_bbref = models.CharField(max_length=20, null=True)
+    key_bbref_minors = models.CharField(max_length=20, null=True)
+    key_fangraphs = models.CharField(max_length=20, null=True)
+    key_npb = models.CharField(max_length=20, null=True)
+    name_last = models.CharField(max_length=100, null=True)
+    name_first = models.CharField(max_length=100, null=True)
+    name_given = models.CharField(max_length=100, null=True)
+    name_suffix = models.CharField(max_length=20, null=True)
+    name_full = models.GeneratedField(
+        expression=Concat(F("name_first"), Value(" "), F("name_last")),
+        output_field=models.CharField(max_length=200),
+        db_persist=True,
+    )
 
     class Meta:
         db_table = 'player_id_infos'


### PR DESCRIPTION
## Summary
- replace raw SQL in player search with ORM query via `PlayerIdInfo`
- expand `PlayerIdInfo` model with name and key fields
- add tests for player search and convert headshot test to ORM

## Testing
- `python backend/manage.py test apps.api` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a62d3a67388326bad9768050edb74b