### PR TITLE
Link schedule final games to GameView

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -6,6 +6,7 @@ import TeamsView from '../views/TeamsView.vue';
 import TeamView from '../views/TeamView.vue';
 import PlayersView from '../views/PlayersView.vue';
 import PlayerView from '../views/PlayerView.vue';
+import GameView from '../views/GameView.vue';
 
 const routes = [
   {
@@ -44,6 +45,12 @@ const routes = [
     name: 'Player',
     component: PlayerView,
     props: route => ({ id: route.params.id, name: route.query.name })
+  },
+  {
+    path: '/game/:game_pk',
+    name: 'Game',
+    component: GameView,
+    props: route => ({ game_pk: route.params.game_pk })
   }
 ];
 

--- a/frontend/src/views/GameView.vue
+++ b/frontend/src/views/GameView.vue
@@ -1,0 +1,14 @@
+<template>
+  <div>
+    <h1>Game {{ game_pk }}</h1>
+  </div>
+</template>
+
+<script setup>
+const { game_pk } = defineProps({
+  game_pk: { type: [String, Number], required: true }
+});
+</script>
+
+<style scoped>
+</style>

--- a/frontend/src/views/ScheduleView.vue
+++ b/frontend/src/views/ScheduleView.vue
@@ -24,7 +24,15 @@
                 {{ teamAbbrev(game.teams.home.team) }}
               </span>
             </div>
-            <div class="game-time">{{ gameTime(game) }}</div>
+            <div class="game-time">
+              <RouterLink
+                v-if="game.status?.detailedState === 'Final'"
+                :to="{ name: 'Game', params: { game_pk: game.gamePk } }"
+              >
+                Final
+              </RouterLink>
+              <span v-else>{{ gameTime(game) }}</span>
+            </div>
             <div class="game-score" v-if="game.status?.detailedState === 'Final'">
               {{ game.teams.away.score }} - {{ game.teams.home.score }}
             </div>


### PR DESCRIPTION
## Summary
- Add navigation to individual game details by making 'Final' statuses link to a new GameView
- Create GameView component and router entry accepting a `game_pk` parameter

## Testing
- ⚠️ `npm test` (Missing script: "test")
- ✅ `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a63c37ee888326a6aeb8b1b8a3ae83