### PR TITLE
Fetch game data for GameView

### DIFF
--- a/backend/apps/api/tests.py
+++ b/backend/apps/api/tests.py
@@ -33,6 +33,24 @@ class ScheduleApiTests(TestCase):
         self.assertEqual(game['teams']['away']['team']['logo_url'], 'logo-url')
 
 
+class GameDataApiTests(TestCase):
+    @patch('apps.api.views.UnifiedDataClient')
+    def test_game_data_endpoint(self, mock_client_cls):
+        mock_client = mock_client_cls.return_value
+        mock_client.get_game_data.return_value = {
+            'teams': {
+                'home': {'team': {'name': 'Home'}, 'score': 5},
+                'away': {'team': {'name': 'Away'}, 'score': 3},
+            }
+        }
+        client = Client()
+        response = client.get('/api/games/123/')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data['teams']['home']['team']['name'], 'Home')
+        self.assertEqual(data['teams']['away']['score'], 3)
+
+
 class StandingsApiTests(TestCase):
     @patch('apps.api.views.UnifiedDataClient')
     def test_standings_endpoint(self, mock_client_cls):

--- a/backend/apps/api/urls.py
+++ b/backend/apps/api/urls.py
@@ -3,6 +3,7 @@ from . import views
 
 urlpatterns = [
     path('schedule/', views.schedule, name='api-schedule'),
+    path('games/<int:game_pk>/', views.game_data, name='api-game-data'),
     path('standings/', views.standings, name='api-standings'),
     path('players/', views.player_search, name='api-player-search'),
     path('players/<int:player_id>/headshot/', views.player_headshot, name='api-player-headshot'),

--- a/backend/apps/api/views.py
+++ b/backend/apps/api/views.py
@@ -45,6 +45,19 @@ def schedule(request):
 
 
 @require_GET
+def game_data(request, game_pk: int):
+    """Return detailed data for a single game."""
+    if UnifiedDataClient is None:
+        return JsonResponse({'error': 'baseball-data-lab library is not installed'}, status=500)
+    try:
+        client = UnifiedDataClient()
+        data = client.get_game_data(game_pk)
+        return JsonResponse(data, safe=False)
+    except Exception as exc:  # pragma: no cover - defensive
+        return JsonResponse({'error': str(exc)}, status=500)
+
+
+@require_GET
 def standings(request):
     """Return standings data for the current season."""
     if UnifiedDataClient is None:

--- a/frontend/src/views/GameView.vue
+++ b/frontend/src/views/GameView.vue
@@ -1,13 +1,33 @@
 <template>
   <div>
     <h1>Game {{ game_pk }}</h1>
+    <div v-if="game">
+      <h2>{{ awayTeam }} @ {{ homeTeam }}</h2>
+      <p>Final Score: {{ awayScore }} - {{ homeScore }}</p>
+    </div>
   </div>
 </template>
 
 <script setup>
+import { ref, onMounted, computed } from 'vue';
+
 const { game_pk } = defineProps({
   game_pk: { type: [String, Number], required: true }
 });
+
+const game = ref(null);
+
+onMounted(async () => {
+  const resp = await fetch(`/api/games/${game_pk}/`);
+  if (resp.ok) {
+    game.value = await resp.json();
+  }
+});
+
+const homeTeam = computed(() => game.value?.teams?.home?.team?.name || '');
+const awayTeam = computed(() => game.value?.teams?.away?.team?.name || '');
+const homeScore = computed(() => game.value?.teams?.home?.score ?? '');
+const awayScore = computed(() => game.value?.teams?.away?.score ?? '');
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- expose `/api/games/<game_pk>/` endpoint that returns UnifiedDataClient game data
- load game details on GameView and show home vs away final score
- test coverage for game data API

## Testing
- `cd backend && python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a63f52bfb4832699d164d0eb6942a7