### PR TITLE
Add team info API endpoint and link GameView names

### DIFF
--- a/backend/apps/api/tests.py
+++ b/backend/apps/api/tests.py
@@ -144,6 +144,24 @@ class TeamSearchApiTests(TestCase):
         self.assertEqual(data[0]['mlbam_team_id'], '111')
 
 
+class TeamInfoApiTests(TestCase):
+    def setUp(self):
+        TeamIdInfo.objects.create(id=1, full_name='Red Sox', mlbam_team_id=111)
+
+    def test_team_info_returns_team(self):
+        client = Client()
+        response = client.get('/api/teams/111/')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data['full_name'], 'Red Sox')
+        self.assertEqual(data['mlbam_team_id'], '111')
+
+    def test_team_info_not_found(self):
+        client = Client()
+        response = client.get('/api/teams/999/')
+        self.assertEqual(response.status_code, 404)
+
+
 class TeamLogoApiTests(TestCase):
     @patch('apps.api.views.UnifiedDataClient')
     def test_team_logo_endpoint(self, mock_client_cls):

--- a/backend/apps/api/urls.py
+++ b/backend/apps/api/urls.py
@@ -8,5 +8,6 @@ urlpatterns = [
     path('players/', views.player_search, name='api-player-search'),
     path('players/<int:player_id>/headshot/', views.player_headshot, name='api-player-headshot'),
     path('teams/', views.team_search, name='api-team-search'),
+    path('teams/<int:mlbam_team_id>/', views.team_info, name='api-team-info'),
     path('teams/<int:team_id>/logo/', views.team_logo, name='api-team-logo'),
 ]

--- a/backend/apps/api/views.py
+++ b/backend/apps/api/views.py
@@ -158,6 +158,26 @@ def team_search(request):
 
 
 @require_GET
+def team_info(request, mlbam_team_id: int):
+    """Return basic team information by MLBAM team ID."""
+    row = (
+        TeamIdInfo.objects
+        .filter(mlbam_team_id=mlbam_team_id)
+        .values('id', 'full_name', 'mlbam_team_id')
+        .first()
+    )
+
+    if row is None:
+        return JsonResponse({'error': 'Team not found'}, status=404)
+
+    mlbam_team_id_value = row.get('mlbam_team_id')
+    if mlbam_team_id_value is not None:
+        row['mlbam_team_id'] = str(mlbam_team_id_value)
+
+    return JsonResponse(row)
+
+
+@require_GET
 def team_logo(request, team_id: int):
     """Return a team's logo image."""
     if UnifiedDataClient is None:

--- a/frontend/src/views/GameView.vue
+++ b/frontend/src/views/GameView.vue
@@ -27,19 +27,19 @@ onMounted(async () => {
   const homeTeamId = game.value.team_home_id;
   const awayTeamId = game.value.team_away_id;
 
-  // if (homeTeamId) {
-  //   const homeResp = await fetch(`/api/teams/${homeTeamId}/`);
-  //   if (homeResp.ok) {
-  //     game.value.homeTeamName = (await homeResp.json()).full_name;
-  //   }
-  // }
+  if (homeTeamId) {
+    const homeResp = await fetch(`/api/teams/${homeTeamId}/`);
+    if (homeResp.ok) {
+      game.value.homeTeamName = (await homeResp.json()).full_name;
+    }
+  }
 
-  // if (awayTeamId) {
-  //   const awayResp = await fetch(`/api/teams${awayTeamId}/`);
-  //   if (awayResp.ok) {
-  //     game.value.awayTeamName = (await awayResp.json()).full_name;
-  //   }
-  // }
+  if (awayTeamId) {
+    const awayResp = await fetch(`/api/teams/${awayTeamId}/`);
+    if (awayResp.ok) {
+      game.value.awayTeamName = (await awayResp.json()).full_name;
+    }
+  }
 });
 
 const homeTeam = computed(() => game.value.homeTeamName || '');


### PR DESCRIPTION
## Summary
- add endpoint to fetch team info by MLBAM team id
- use new endpoint in GameView to load home and away team names
- test coverage for team info API

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (127.0.0.1), port 5432 failed: Connection refused)*
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68a64934e5d48326ab718a74bcda0ea6