### PR TITLE
refactor: extract reusable search autocomplete component

### DIFF
--- a/frontend/src/components/SearchAutocomplete.vue
+++ b/frontend/src/components/SearchAutocomplete.vue
@@ -1,0 +1,75 @@
+<template>
+  <AutoComplete
+    v-model="selected"
+    :suggestions="suggestions"
+    @complete="search"
+    @item-select="onSelect"
+    :optionLabel="optionLabel"
+    :placeholder="placeholder"
+  >
+    <template #option="{ option }">
+      <div>{{ option[optionLabel] }}</div>
+    </template>
+  </AutoComplete>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import AutoComplete from 'primevue/autocomplete';
+import 'primevue/autocomplete/style';
+import { useRouter } from 'vue-router';
+
+const props = defineProps({
+  placeholder: {
+    type: String,
+    required: true
+  },
+  optionLabel: {
+    type: String,
+    required: true
+  },
+  searchEndpoint: {
+    type: String,
+    required: true
+  },
+  routeName: {
+    type: String,
+    required: true
+  }
+});
+
+const selected = ref(null);
+const suggestions = ref([]);
+const router = useRouter();
+
+async function search(event) {
+  const query = event.query;
+  if (!query) {
+    suggestions.value = [];
+    return;
+  }
+  try {
+    const resp = await fetch(`${props.searchEndpoint}?q=${encodeURIComponent(query)}`);
+    if (resp.ok) {
+      suggestions.value = await resp.json();
+    } else {
+      suggestions.value = [];
+    }
+  } catch (err) {
+    suggestions.value = [];
+  }
+}
+
+function onSelect(event) {
+  const item = event.value;
+  router.push({
+    name: props.routeName,
+    params: { id: item.id },
+    query: { name: item[props.optionLabel] }
+  });
+}
+</script>
+
+<style scoped>
+</style>
+

--- a/frontend/src/views/PlayersView.vue
+++ b/frontend/src/views/PlayersView.vue
@@ -1,58 +1,19 @@
 <template>
   <div>
     <h1>Players</h1>
-    <AutoComplete
-      v-model="selectedPlayer"
-      :suggestions="suggestions"
-      @complete="searchPlayers"
-      @item-select="onSelect"
-      optionLabel="name_full"
+    <SearchAutocomplete
       placeholder="Search for a player"
-    >
-      <template #option="{ option }">
-        <div>{{ option.name_full }}</div>
-      </template>
-    </AutoComplete>
+      optionLabel="name_full"
+      searchEndpoint="/api/players/"
+      routeName="Player"
+    />
   </div>
 </template>
 
 <script setup>
-import { ref } from 'vue';
-import AutoComplete from 'primevue/autocomplete';
-import 'primevue/autocomplete/style';
-import { useRouter } from 'vue-router';
-
-const selectedPlayer = ref(null);
-const suggestions = ref([]);
-const router = useRouter();
-
-async function searchPlayers(event) {
-  const query = event.query;
-  if (!query) {
-    suggestions.value = [];
-    return;
-  }
-  try {
-    const resp = await fetch(`/api/players/?q=${encodeURIComponent(query)}`);
-    if (resp.ok) {
-      suggestions.value = await resp.json();
-    } else {
-      suggestions.value = [];
-    }
-  } catch (err) {
-    suggestions.value = [];
-  }
-}
-
-function onSelect(event) {
-  const player = event.value;
-  router.push({
-    name: 'Player',
-    params: { id: player.id },
-    query: { name: player.name_full }
-  });
-}
+import SearchAutocomplete from '../components/SearchAutocomplete.vue';
 </script>
 
 <style scoped>
 </style>
+

--- a/frontend/src/views/TeamsView.vue
+++ b/frontend/src/views/TeamsView.vue
@@ -1,60 +1,19 @@
-
-
 <template>
   <div>
     <h1>Teams</h1>
-    <AutoComplete
-      v-model="selectedTeam"
-      :suggestions="suggestions"
-      @complete="searchTeams"
-      @item-select="onSelect"
-      optionLabel="full_name"
+    <SearchAutocomplete
       placeholder="Search for a team"
-    >
-      <template #option="{ option }">
-        <div>{{ option.full_name }}</div>
-      </template>
-    </AutoComplete>
+      optionLabel="full_name"
+      searchEndpoint="/api/teams/"
+      routeName="Team"
+    />
   </div>
 </template>
 
 <script setup>
-import { ref } from 'vue';
-import AutoComplete from 'primevue/autocomplete';
-import 'primevue/autocomplete/style';
-import { useRouter } from 'vue-router';
-
-const selectedTeam = ref(null);
-const suggestions = ref([]);
-const router = useRouter();
-
-async function searchTeams(event) {
-  const query = event.query;
-  if (!query) {
-    suggestions.value = [];
-    return;
-  }
-  try {
-    const resp = await fetch(`/api/teams/?q=${encodeURIComponent(query)}`);
-    if (resp.ok) {
-      suggestions.value = await resp.json();
-    } else {
-      suggestions.value = [];
-    }
-  } catch (err) {
-    suggestions.value = [];
-  }
-}
-
-function onSelect(event) {
-  const team = event.value;
-  router.push({
-    name: 'Team',
-    params: { id: team.id },
-    query: { name: team.full_name }
-  });
-}
+import SearchAutocomplete from '../components/SearchAutocomplete.vue';
 </script>
 
 <style scoped>
 </style>
+


### PR DESCRIPTION
## Summary
- add SearchAutocomplete component to centralize autocomplete logic
- use SearchAutocomplete in players and teams views

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68a65fda239c83268d7d47dd86bcc623