### PR TITLE
Add team record endpoint and display team record on team page

### DIFF
--- a/backend/apps/api/tests.py
+++ b/backend/apps/api/tests.py
@@ -177,3 +177,29 @@ class TeamLogoApiTests(TestCase):
         self.assertEqual(response.content, b'logo-url')
         self.assertEqual(response['Content-Type'], 'text/plain')
         mock_client.get_team_logo_url.assert_called_once_with(555)
+
+
+class TeamRecordApiTests(TestCase):
+    @patch('apps.api.views.UnifiedDataClient')
+    def test_team_record_endpoint(self, mock_client_cls):
+        mock_client = mock_client_cls.return_value
+        mock_client.get_team_record_for_season.return_value = {
+            'wins': 10,
+            'losses': 5,
+            'divisionRank': '1',
+            'streak': {
+                'streakType': 'wins',
+                'streakNumber': 3,
+                'streakCode': 'W3'
+            }
+        }
+
+        TeamIdInfo.objects.create(id=1, mlbam_team_id=555, full_name='Team A')
+
+        client = Client()
+        response = client.get('/api/teams/1/record/', {'season': '2025'})
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data['wins'], 10)
+        mock_client.get_team_record_for_season.assert_called_once_with(555, 2025)

--- a/backend/apps/api/urls.py
+++ b/backend/apps/api/urls.py
@@ -10,4 +10,5 @@ urlpatterns = [
     path('teams/', views.team_search, name='api-team-search'),
     path('teams/<int:mlbam_team_id>/', views.team_info, name='api-team-info'),
     path('teams/<int:team_id>/logo/', views.team_logo, name='api-team-logo'),
+    path('teams/<int:team_id>/record/', views.team_record, name='api-team-record'),
 ]

--- a/frontend/src/views/TeamView.vue
+++ b/frontend/src/views/TeamView.vue
@@ -5,6 +5,13 @@
     <img v-if="teamLogoSrc" :src="teamLogoSrc" alt="Team Logo" />
     <p v-else>Loading logo…</p>
 
+    <div v-if="teamRecord">
+      <p>Record: {{ teamRecord.wins }}-{{ teamRecord.losses }}</p>
+      <p>Division Rank: {{ teamRecord.divisionRank }}</p>
+      <p>Streak: {{ teamRecord.streak?.streakCode }}</p>
+    </div>
+    <p v-else>Loading record…</p>
+
   </div>
 </template>
 
@@ -17,6 +24,7 @@ const { id, name } = defineProps({
 });
 
 const teamLogoSrc = ref("");
+const teamRecord = ref(null);
 
 // fetcher for plain-text URL
 async function loadLogo(teamId) {
@@ -31,13 +39,27 @@ async function loadLogo(teamId) {
   }
 }
 
+async function loadRecord(teamId) {
+  try {
+    const res = await fetch(`/api/teams/${teamId}/record/`);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    teamRecord.value = await res.json();
+  } catch (e) {
+    console.error("Failed to fetch team record:", e);
+    teamRecord.value = null;
+  }
+}
 
 
 onMounted(() => {
-  loadLogo(id)
+  loadLogo(id);
+  loadRecord(id);
 });
 
-watch(() => id, (newId) => loadLogo(newId));
+watch(() => id, (newId) => {
+  loadLogo(newId);
+  loadRecord(newId);
+});
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- add `/api/teams/<team_id>/record/` endpoint using `get_team_record_for_season`
- show record, division rank, and streak on TeamView
- cover new endpoint with unit test

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7621f4da0832697b53f461bca500b