### PR TITLE
Add team recent schedule endpoint and TeamView schedule display

### DIFF
--- a/backend/apps/api/tests.py
+++ b/backend/apps/api/tests.py
@@ -203,3 +203,29 @@ class TeamRecordApiTests(TestCase):
         data = response.json()
         self.assertEqual(data['wins'], 10)
         mock_client.get_team_record_for_season.assert_called_once_with(555, 2025)
+
+
+class TeamRecentScheduleApiTests(TestCase):
+    @patch('apps.api.views.UnifiedDataClient')
+    def test_team_recent_schedule_endpoint(self, mock_client_cls):
+        mock_client = mock_client_cls.return_value
+        mock_client.get_recent_schedule_for_team.return_value = {
+            'id': 555,
+            'previousGameSchedule': {'dates': []},
+            'nextGameSchedule': {'dates': []}
+        }
+
+        TeamIdInfo.objects.create(id=1, mlbam_team_id=555, full_name='Team A')
+
+        client = Client()
+        response = client.get('/api/teams/1/recent_schedule/')
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data['id'], 555)
+        mock_client.get_recent_schedule_for_team.assert_called_once_with(555)
+
+    def test_team_recent_schedule_team_not_found(self):
+        client = Client()
+        response = client.get('/api/teams/1/recent_schedule/')
+        self.assertEqual(response.status_code, 404)

--- a/backend/apps/api/urls.py
+++ b/backend/apps/api/urls.py
@@ -11,4 +11,5 @@ urlpatterns = [
     path('teams/<int:mlbam_team_id>/', views.team_info, name='api-team-info'),
     path('teams/<int:team_id>/logo/', views.team_logo, name='api-team-logo'),
     path('teams/<int:team_id>/record/', views.team_record, name='api-team-record'),
+    path('teams/<int:team_id>/recent_schedule/', views.team_recent_schedule, name='api-team-recent-schedule'),
 ]

--- a/backend/apps/api/views.py
+++ b/backend/apps/api/views.py
@@ -235,3 +235,26 @@ def team_record(request, team_id: int):
         return JsonResponse(record, safe=False)
     except Exception as exc:  # pragma: no cover - defensive
         return JsonResponse({'error': str(exc)}, status=500)
+
+
+@require_GET
+def team_recent_schedule(request, team_id: int):
+    """Return the previous and next five games for a team."""
+    if UnifiedDataClient is None:
+        return JsonResponse({'error': 'baseball-data-lab library is not installed'}, status=500)
+
+    mlbam_team_id = (
+        TeamIdInfo.objects.filter(id=team_id)
+        .values_list('mlbam_team_id', flat=True)
+        .first()
+    )
+
+    if mlbam_team_id is None:
+        return JsonResponse({'error': 'Team not found'}, status=404)
+
+    try:
+        client = UnifiedDataClient()
+        schedule = client.get_recent_schedule_for_team(int(mlbam_team_id))
+        return JsonResponse(schedule, safe=False)
+    except Exception as exc:  # pragma: no cover - defensive
+        return JsonResponse({'error': str(exc)}, status=500)

--- a/frontend/src/views/TeamView.vue
+++ b/frontend/src/views/TeamView.vue
@@ -22,11 +22,33 @@
     <div v-if="teamRecord">
       <p>Streak: {{ teamRecord.streak?.streakCode }}</p>
     </div>
+
+    <div v-if="recentSchedule">
+      <div class="schedule-section">
+        <h2>Previous Games</h2>
+        <ul>
+          <li v-for="game in previousGames" :key="`prev-` + game.gamePk">
+            {{ formatDate(game.gameDate) }} {{ describeGame(game, true) }}
+          </li>
+        </ul>
+      </div>
+      <div class="schedule-section">
+        <h2>Upcoming Games</h2>
+        <ul>
+          <li v-for="game in nextGames" :key="`next-` + game.gamePk">
+            {{ formatDate(game.gameDate) }} {{ describeGame(game, false) }}
+          </li>
+        </ul>
+      </div>
+    </div>
+    <div v-else>
+      <p>Loading schedule…</p>
+    </div>
   </div>
 </template>
 
 <script setup>
-import { ref, watch, onMounted } from 'vue';
+import { ref, watch, onMounted, computed } from 'vue';
 
 const { id, name } = defineProps({
   id: { type: [String, Number], required: true },
@@ -35,6 +57,7 @@ const { id, name } = defineProps({
 
 const teamLogoSrc = ref("");
 const teamRecord = ref(null);
+const recentSchedule = ref(null);
 
 // fetcher for plain-text URL
 async function loadLogo(teamId) {
@@ -64,11 +87,13 @@ async function loadRecord(teamId) {
 onMounted(() => {
   loadLogo(id);
   loadRecord(id);
+  loadRecentSchedule(id);
 });
 
 watch(() => id, (newId) => {
   loadLogo(newId);
   loadRecord(newId);
+  loadRecentSchedule(newId);
 });
 
 function formatRank(rank) {
@@ -79,6 +104,51 @@ function formatRank(rank) {
   if (j === 2 && k !== 12) return `${rank}nd Place`;
   if (j === 3 && k !== 13) return `${rank}rd Place`;
   return `${rank}th Place`;
+}
+
+async function loadRecentSchedule(teamId) {
+  try {
+    const res = await fetch(`/api/teams/${teamId}/recent_schedule/`);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    recentSchedule.value = await res.json();
+  } catch (e) {
+    console.error("Failed to fetch recent schedule:", e);
+    recentSchedule.value = null;
+  }
+}
+
+const previousGames = computed(() => {
+  const dates = recentSchedule.value?.previousGameSchedule?.dates ?? [];
+  return dates.flatMap(d => d.games);
+});
+
+const nextGames = computed(() => {
+  const dates = recentSchedule.value?.nextGameSchedule?.dates ?? [];
+  return dates.flatMap(d => d.games);
+});
+
+const mlbamTeamId = computed(() => recentSchedule.value?.id);
+
+function formatDate(dateStr) {
+  const d = new Date(dateStr);
+  return isNaN(d) ? dateStr : d.toLocaleDateString();
+}
+
+function describeGame(game, includeScore) {
+  const teamId = mlbamTeamId.value;
+  const home = game.teams.home;
+  const away = game.teams.away;
+  const isHome = home.team.id === teamId;
+  const opponent = isHome ? away.team.name : home.team.name;
+  const vsAt = isHome ? 'vs' : '@';
+  let result = '';
+  if (includeScore && home.score != null && away.score != null) {
+    const usScore = isHome ? home.score : away.score;
+    const oppScore = isHome ? away.score : home.score;
+    const outcome = usScore > oppScore ? 'W' : (usScore < oppScore ? 'L' : 'T');
+    result = ` ${outcome} ${usScore}-${oppScore}`;
+  }
+  return `${vsAt} ${opponent}${result}`;
 }
 </script>
 
@@ -110,6 +180,19 @@ function formatRank(rank) {
   font-weight: 600;
   color: #555;
   padding-top: 8px;
+}
+
+.schedule-section {
+  margin-top: 1rem;
+}
+
+.schedule-section ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+.schedule-section li {
+  margin-bottom: 0.25rem;
 }
 
 </style>


### PR DESCRIPTION
## Summary
- expose recent schedule API returning previous and next five games for a team
- show a team's previous and upcoming games on TeamView
- add tests for the new API endpoint

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68a78a8b88cc832683fda8bd2b395570