### PR TITLE
feat: add team summary stats

### DIFF
--- a/frontend/src/views/TeamView.vue
+++ b/frontend/src/views/TeamView.vue
@@ -19,9 +19,28 @@
       </div>
     </div>
 
-    <div v-if="teamRecord">
-      <p>Streak: {{ teamRecord.streak?.streakCode }}</p>
-    </div>
+    <table v-if="teamRecord" class="team-stats">
+      <thead>
+        <tr>
+          <th>Streak</th>
+          <th>Last 10</th>
+          <th>Last 30</th>
+          <th>RS</th>
+          <th>RA</th>
+          <th>rDiff</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>{{ streakCode }}</td>
+          <td>{{ lastTen }}</td>
+          <td>{{ lastThirty }}</td>
+          <td>{{ runsScored }}</td>
+          <td>{{ runsAllowed }}</td>
+          <td>{{ runDifferential }}</td>
+        </tr>
+      </tbody>
+    </table>
 
     <div class="recent-schedule" v-if="recentSchedule">
       <div class="schedule-section">
@@ -129,6 +148,22 @@ const nextGames = computed(() => {
 
 const mlbamTeamId = computed(() => recentSchedule.value?.id);
 
+const streakCode = computed(() => teamRecord.value?.streak?.streakCode || "");
+
+const lastTen = computed(() => {
+  const split = teamRecord.value?.records?.splitRecords?.find(r => r.type === 'lastTen');
+  return split ? `${split.wins}-${split.losses}` : "";
+});
+
+const lastThirty = computed(() => {
+  const split = teamRecord.value?.records?.splitRecords?.find(r => r.type === 'lastThirty');
+  return split ? `${split.wins}-${split.losses}` : "";
+});
+
+const runsScored = computed(() => teamRecord.value?.runsScored ?? "");
+const runsAllowed = computed(() => teamRecord.value?.runsAllowed ?? "");
+const runDifferential = computed(() => teamRecord.value?.runDifferential ?? "");
+
 function formatDate(dateStr) {
   const d = new Date(dateStr);
   return isNaN(d) ? dateStr : d.toLocaleDateString();
@@ -180,6 +215,24 @@ function describeGame(game, includeScore) {
   font-weight: 600;
   color: #555;
   padding-top: 8px;
+}
+
+.team-stats {
+  margin: 0 auto 2rem;
+  border-collapse: collapse;
+  font-family: proxima-nova, 'open Sans', Helvetica, Arial, sans-serif;
+}
+
+.team-stats th,
+.team-stats td {
+  border: 2px solid #555;
+  padding: 0.5rem 1rem;
+  text-align: center;
+}
+
+.team-stats th {
+  background-color: #eee;
+  font-weight: 600;
 }
 
 .recent-schedule {


### PR DESCRIPTION
## Summary
- display team streak, recent records, and run stats at top of TeamView
- style team summary with table layout above schedule

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*
- `npm test` *(fails: No test files found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a7943e06c883269b65502298937166