### PR TITLE
Allow navigation from past games to GameView

### DIFF
--- a/frontend/src/views/TeamView.vue
+++ b/frontend/src/views/TeamView.vue
@@ -46,7 +46,11 @@
         <h2>Previous Games</h2>
         <ul>
           <li v-for="game in previousGames" :key="`prev-` + game.gamePk">
-            {{ formatDate(game.gameDate) }} {{ describeGame(game, true) }}
+            <RouterLink
+              :to="{ name: 'Game', params: { game_pk: game.gamePk } }"
+            >
+              {{ formatDate(game.gameDate) }} {{ describeGame(game, true) }}
+            </RouterLink>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
## Summary
- Link each game in TeamView's "Previous Games" list to its GameView page

## Testing
- `npm test` (fails: No test files found)
- `npx vitest run --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a79b6250308326b15ee7262126222e