### PR TITLE
Style game view with card layout

### DIFF
--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -1,0 +1,3 @@
+body {
+  background: #f5f5f5;
+}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -6,6 +6,7 @@ import { useScheduleStore } from './store/schedule';
 import PrimeVue from 'primevue/config';
 import Aura from '@primevue/themes/aura';
 import 'primeicons/primeicons.css';
+import './global.css';
 
 const scheduleElement = document.getElementById('schedule-data');
 const scheduleData = scheduleElement ? JSON.parse(scheduleElement.textContent) : [];

--- a/frontend/src/views/GameView.vue
+++ b/frontend/src/views/GameView.vue
@@ -3,81 +3,85 @@
     <div v-if="game">
       <h2>{{ awayTeam }} @ {{ homeTeam }}</h2>
       <h3 class="game-date">{{ game.gameDate }}</h3>
-      <table v-if="innings.length" class="linescore" :style="{ '--team-color': '#f0f0f0' }">
-        <thead>
-          <tr>
-            <th></th>
-            <th v-for="inning in innings" :key="inning.num">{{ inning.num }}</th>
-            <th>R</th>
-            <th>H</th>
-            <th>E</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th :style="{ backgroundColor: awayColor }">{{ awayTeam }}</th>
-            <td v-for="inning in innings" :key="`away-` + inning.num">{{ inning.away?.runs ?? '' }}</td>
-            <td>{{ linescoreTeams.away?.runs ?? '' }}</td>
-            <td>{{ linescoreTeams.away?.hits ?? '' }}</td>
-            <td>{{ linescoreTeams.away?.errors ?? '' }}</td>
-          </tr>
-          <tr>
-            <th :style="{ backgroundColor: homeColor }">{{ homeTeam }}</th>
-            <td v-for="inning in innings" :key="`home-` + inning.num">{{ inning.home?.runs ?? '' }}</td>
-            <td>{{ linescoreTeams.home?.runs ?? '' }}</td>
-            <td>{{ linescoreTeams.home?.hits ?? '' }}</td>
-            <td>{{ linescoreTeams.home?.errors ?? '' }}</td>
-          </tr>
-        </tbody>
-      </table>
+      <div v-if="innings.length" class="card">
+        <table class="linescore" :style="{ '--team-color': '#f0f0f0' }">
+          <thead>
+            <tr>
+              <th></th>
+              <th v-for="inning in innings" :key="inning.num">{{ inning.num }}</th>
+              <th>R</th>
+              <th>H</th>
+              <th>E</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th :style="{ backgroundColor: awayColor }">{{ awayTeam }}</th>
+              <td v-for="inning in innings" :key="`away-` + inning.num">{{ inning.away?.runs ?? '' }}</td>
+              <td>{{ linescoreTeams.away?.runs ?? '' }}</td>
+              <td>{{ linescoreTeams.away?.hits ?? '' }}</td>
+              <td>{{ linescoreTeams.away?.errors ?? '' }}</td>
+            </tr>
+            <tr>
+              <th :style="{ backgroundColor: homeColor }">{{ homeTeam }}</th>
+              <td v-for="inning in innings" :key="`home-` + inning.num">{{ inning.home?.runs ?? '' }}</td>
+              <td>{{ linescoreTeams.home?.runs ?? '' }}</td>
+              <td>{{ linescoreTeams.home?.hits ?? '' }}</td>
+              <td>{{ linescoreTeams.home?.errors ?? '' }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
       <div v-if="boxscore" class="boxscore">
         <h3>Boxscore</h3>
-        <div v-for="side in ['away', 'home']" :key="side" class="team-boxscore">
-          <h4>{{ side === 'away' ? awayTeam : homeTeam }}</h4>
-          <table class="boxscore-table" :style="{ '--team-color': side === 'away' ? awayColor : homeColor }">
-            <thead>
-              <tr>
-                <th>Batter</th>
-                <th>AB</th>
-                <th>R</th>
-                <th>H</th>
-                <th>RBI</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="id in boxscoreTeams[side]?.batters ?? []" :key="`bat-` + id">
-                <td>{{ playerName(side, id) }}</td>
-                <td>{{ playerStat(side, id, 'batting', 'atBats') }}</td>
-                <td>{{ playerStat(side, id, 'batting', 'runs') }}</td>
-                <td>{{ playerStat(side, id, 'batting', 'hits') }}</td>
-                <td>{{ playerStat(side, id, 'batting', 'rbi') }}</td>
-              </tr>
-            </tbody>
-          </table>
-          <table class="boxscore-table" :style="{ '--team-color': side === 'away' ? awayColor : homeColor }">
-            <thead>
-              <tr>
-                <th>Pitcher</th>
-                <th>IP</th>
-                <th>H</th>
-                <th>R</th>
-                <th>ER</th>
-                <th>BB</th>
-                <th>K</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="id in boxscoreTeams[side]?.pitchers ?? []" :key="`pit-` + id">
-                <td>{{ playerName(side, id) }}</td>
-                <td>{{ playerStat(side, id, 'pitching', 'inningsPitched') }}</td>
-                <td>{{ playerStat(side, id, 'pitching', 'hits') }}</td>
-                <td>{{ playerStat(side, id, 'pitching', 'runs') }}</td>
-                <td>{{ playerStat(side, id, 'pitching', 'earnedRuns') }}</td>
-                <td>{{ playerStat(side, id, 'pitching', 'baseOnBalls') }}</td>
-                <td>{{ playerStat(side, id, 'pitching', 'strikeOuts') }}</td>
-              </tr>
-            </tbody>
-          </table>
+        <div v-for="side in ['away', 'home']" :key="side" class="card">
+          <div class="team-boxscore">
+            <h4>{{ side === 'away' ? awayTeam : homeTeam }}</h4>
+            <table class="boxscore-table" :style="{ '--team-color': side === 'away' ? awayColor : homeColor }">
+              <thead>
+                <tr>
+                  <th>Batter</th>
+                  <th>AB</th>
+                  <th>R</th>
+                  <th>H</th>
+                  <th>RBI</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="id in boxscoreTeams[side]?.batters ?? []" :key="`bat-` + id">
+                  <td>{{ playerName(side, id) }}</td>
+                  <td>{{ playerStat(side, id, 'batting', 'atBats') }}</td>
+                  <td>{{ playerStat(side, id, 'batting', 'runs') }}</td>
+                  <td>{{ playerStat(side, id, 'batting', 'hits') }}</td>
+                  <td>{{ playerStat(side, id, 'batting', 'rbi') }}</td>
+                </tr>
+              </tbody>
+            </table>
+            <table class="boxscore-table" :style="{ '--team-color': side === 'away' ? awayColor : homeColor }">
+              <thead>
+                <tr>
+                  <th>Pitcher</th>
+                  <th>IP</th>
+                  <th>H</th>
+                  <th>R</th>
+                  <th>ER</th>
+                  <th>BB</th>
+                  <th>K</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="id in boxscoreTeams[side]?.pitchers ?? []" :key="`pit-` + id">
+                  <td>{{ playerName(side, id) }}</td>
+                  <td>{{ playerStat(side, id, 'pitching', 'inningsPitched') }}</td>
+                  <td>{{ playerStat(side, id, 'pitching', 'hits') }}</td>
+                  <td>{{ playerStat(side, id, 'pitching', 'runs') }}</td>
+                  <td>{{ playerStat(side, id, 'pitching', 'earnedRuns') }}</td>
+                  <td>{{ playerStat(side, id, 'pitching', 'baseOnBalls') }}</td>
+                  <td>{{ playerStat(side, id, 'pitching', 'strikeOuts') }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
         </div>
       </div>
     </div>
@@ -180,14 +184,18 @@ function playerStat(side, id, statType, field) {
   width: 1000px;
 }
 
+
 .boxscore h3 {
   flex: 0 0 100%;   /* always full width */
   margin: 0 0 1rem;
 }
 
-.team-boxscore {
+.boxscore > .card {
   flex: 0 0 50%;    /* each takes half width */
   box-sizing: border-box;
+}
+
+.team-boxscore {
   padding: 0.5rem;
 }
 
@@ -207,6 +215,14 @@ function playerStat(side, id, statType, field) {
 }
 .boxscore-table tbody tr:nth-child(even) {
   background-color: #f9f9f9;
+}
+
+.card {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  padding: 16px;
+  margin-bottom: 20px;
 }
 
 .game-date {


### PR DESCRIPTION
## Summary
- Wrap linescore table and team boxscore sections in a reusable `card` container
- Add card styling and global body background to improve contrast

## Testing
- `npm test` *(fails: No test files found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7b8c14a088326bcc1fa1f86c3f0f5