### PR TITLE
feat: add Roboto font and refine spacing

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <title>Baseball Data Lab Web</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="vue-app"></div>

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -1,3 +1,5 @@
 body {
   background: #f5f5f5;
+  font-family: 'Roboto', sans-serif;
+  line-height: 1.4;
 }

--- a/frontend/src/views/GameView.vue
+++ b/frontend/src/views/GameView.vue
@@ -207,8 +207,15 @@ function playerStat(side, id, statType, field) {
 .linescore th,
 .linescore td {
   border: 1px solid #ccc;
-  padding: 4px 8px;
   text-align: center;
+}
+
+.linescore th {
+  padding: 8px 12px;
+}
+
+.linescore td {
+  padding: 4px 8px;
 }
 .linescore tbody tr:nth-child(even) {
   background-color: #f9f9f9;
@@ -251,8 +258,15 @@ function playerStat(side, id, statType, field) {
 .boxscore-table th,
 .boxscore-table td {
   border: 1px solid #ccc;
-  padding: 4px 8px;
   text-align: center;
+}
+
+.boxscore-table th {
+  padding: 8px 12px;
+}
+
+.boxscore-table td {
+  padding: 4px 8px;
 }
 .boxscore-table tbody tr:nth-child(even) {
   background-color: #f9f9f9;
@@ -267,8 +281,8 @@ function playerStat(side, id, statType, field) {
 }
 
 .game-date {
-  font-size: 20px;
+  font-size: 1.2rem;
   color: #555;
-  margin-top: -8px;
+  margin: 0 0 1rem;
 }
 </style>


### PR DESCRIPTION
## Summary
- load Google Roboto font globally and apply base typography
- improve game date heading spacing
- increase table header padding for consistent spacing

## Testing
- `npm test` *(fails: No test files found)*
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c710410c832690cb974a733ada92