### PR TITLE
Include boxscore data in game API

### DIFF
--- a/backend/apps/api/tests.py
+++ b/backend/apps/api/tests.py
@@ -41,7 +41,13 @@ class GameDataApiTests(TestCase):
             'teams': {
                 'home': {'team': {'name': 'Home'}, 'score': 5},
                 'away': {'team': {'name': 'Away'}, 'score': 3},
-            }
+            },
+            'home_team_data': {'id': 1},
+            'away_team_data': {'id': 2},
+        }
+        mock_client.get_team_spot_url.return_value = 'logo-url'
+        mock_client.get_game_boxscore_data.return_value = {
+            'info': [{'label': 'Att', 'value': '10,000'}]
         }
         client = Client()
         response = client.get('/api/games/123/')
@@ -49,6 +55,12 @@ class GameDataApiTests(TestCase):
         data = response.json()
         self.assertEqual(data['teams']['home']['team']['name'], 'Home')
         self.assertEqual(data['teams']['away']['score'], 3)
+        # boxscore data should be merged into liveData
+        self.assertEqual(
+            data['liveData']['boxscore']['info'][0]['label'],
+            'Att',
+        )
+        mock_client.get_game_boxscore_data.assert_called_once_with(123)
 
 
 class StandingsApiTests(TestCase):

--- a/backend/apps/api/views.py
+++ b/backend/apps/api/views.py
@@ -54,6 +54,12 @@ def game_data(request, game_pk: int):
     try:
         client = UnifiedDataClient()
         data = client.get_game_data(game_pk)
+        # Pull additional boxscore details for summary information
+        try:
+            boxscore = client.get_game_boxscore_data(game_pk)
+            data.setdefault('liveData', {})['boxscore'] = boxscore
+        except Exception:  # pragma: no cover - downstream service failure
+            pass
         data['home_team_data']['logo_url'] = client.get_team_spot_url(data['home_team_data']['id'], 32)
         data['away_team_data']['logo_url'] = client.get_team_spot_url(data['away_team_data']['id'], 32)
         return JsonResponse(data, safe=False)


### PR DESCRIPTION
## Summary
- Fetch boxscore details for games via `get_game_boxscore_data`
- Merge boxscore response into API output so summary info is available
- Update game data API test to cover boxscore retrieval

## Testing
- `pip install -r requirements.txt`
- `python manage.py test` (fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)
- `npm test` (fails: No test files found, exiting with code 1)


------
https://chatgpt.com/codex/tasks/task_e_68a8ceeaba2c8326964b01102b22eac9