### PR TITLE
feat: add home page hero section

### DIFF
--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -1,22 +1,49 @@
 <template>
-  <div class="home">
-    <img src="http://localhost:5173/logo.png" alt="Logo" />
-  </div>
+  <section class="hero">
+    <div class="hero-content">
+      <img src="/logo.png" alt="Baseball Data Lab logo" class="logo" />
+      <h1 class="tagline">Data-Driven Baseball Insights</h1>
+      <p class="description">
+        Advanced stats, interactive visualizations, and real-time standings—your
+        baseball analytics hub.
+      </p>
+    </div>
+  </section>
 </template>
 
 <script setup>
 </script>
 
 <style scoped>
-.home {
+.hero {
   display: flex;
-  justify-content: center;
   align-items: center;
-  height: 100vh;
-  max-width: 800px;
-  margin: auto;
+  justify-content: center;
+  text-align: center;
+  min-height: 100vh;
+  background: linear-gradient(135deg, #1e3a8a, #1e40af);
+  color: #fff;
+  padding: 2rem;
 }
-img {
-  max-width: 500px;
+
+.hero-content {
+  max-width: 800px;
+}
+
+.logo {
+  max-width: 200px;
+  margin-bottom: 1.5rem;
+}
+
+.tagline {
+  font-size: 2.5rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+
+.description {
+  font-size: 1.25rem;
+  max-width: 600px;
+  margin: 0 auto;
 }
 </style>


### PR DESCRIPTION
## Summary
- add hero section with tagline and description
- style home page with gradient background

## Testing
- `npm test` (fails: No test files found, exiting with code 1)

------
https://chatgpt.com/codex/tasks/task_e_68a8e717bb588326b03b4057a273f54d