### PR TITLE
feat: add feature highlights and top stat to home view

### DIFF
--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -3,6 +3,15 @@
     <div class="hero-content">
       <img src="http://localhost:5173/logo.png" alt="Baseball Data Lab logo" class="logo" />
       <h1 class="tagline">Data-Driven Baseball Insights</h1>
+
+      <div class="feature-cards">
+        <div class="feature-card" v-for="feature in features" :key="feature.title">
+          <i :class="['pi', feature.icon, 'feature-icon']" />
+          <h3 class="feature-title">{{ feature.title }}</h3>
+          <p class="feature-description">{{ feature.description }}</p>
+        </div>
+      </div>
+
       <p class="description">
         Advanced stats, interactive visualizations, and real-time standings—your
         baseball analytics hub.
@@ -11,6 +20,12 @@
         Welcome! Get started by exploring the schedule, diving into player stats,
         or building your own team.
       </p>
+
+      <div class="top-stat" v-if="topStat">
+        <h2>Top Stat of the Day</h2>
+        <p>{{ topStat }}</p>
+      </div>
+
       <div class="cta-buttons">
         <router-link to="/schedule" class="cta-button">View Schedule</router-link>
         <router-link to="/players" class="cta-button">Explore Player Stats</router-link>
@@ -21,6 +36,46 @@
 </template>
 
 <script setup>
+import { ref, onMounted } from 'vue';
+
+const features = [
+  {
+    title: 'Schedule',
+    icon: 'pi-calendar',
+    description: 'See upcoming games and past results.'
+  },
+  {
+    title: 'Standings',
+    icon: 'pi-chart-bar',
+    description: 'Track how your favorite teams stack up.'
+  },
+  {
+    title: 'Teams',
+    icon: 'pi-users',
+    description: 'Browse team rosters and stats.'
+  },
+  {
+    title: 'Players',
+    icon: 'pi-user',
+    description: 'Dive into detailed player analytics.'
+  }
+];
+
+const topStat = ref('');
+
+onMounted(async () => {
+  try {
+    const response = await fetch('/api/top-stat');
+    if (response.ok) {
+      const data = await response.json();
+      topStat.value = data.stat;
+      return;
+    }
+  } catch (e) {
+    // Ignore errors and use fallback text
+  }
+  topStat.value = 'Shohei Ohtani leads the league with 45 HRs.';
+});
 </script>
 
 <style scoped>
@@ -50,6 +105,34 @@
   margin-bottom: 1rem;
 }
 
+.feature-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1.5rem;
+  margin: 2rem 0;
+}
+
+.feature-card {
+  background: rgba(255, 255, 255, 0.1);
+  padding: 1rem;
+  border-radius: 0.5rem;
+}
+
+.feature-icon {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+}
+
+.feature-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.feature-description {
+  font-size: 0.95rem;
+}
+
 .description {
   font-size: 1.25rem;
   max-width: 600px;
@@ -59,6 +142,13 @@
 .welcome-message {
   margin-top: 1rem;
   font-size: 1.1rem;
+}
+
+.top-stat {
+  margin-top: 2rem;
+  background: rgba(255, 255, 255, 0.1);
+  padding: 1rem;
+  border-radius: 0.5rem;
 }
 
 .cta-buttons {


### PR DESCRIPTION
## Summary
- add feature cards highlighting schedule, standings, teams and players with icons
- show top stat of the day with fallback text

## Testing
- `npm test --prefix frontend` *(fails: No test files found)*
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a90aaec068832684e5c71fbdc1c9af