### PR TITLE
Load built stylesheet so PrimeIcons render

### DIFF
--- a/backend/apps/web/templates/web/base.html
+++ b/backend/apps/web/templates/web/base.html
@@ -24,6 +24,7 @@
             font-weight: bold;
         }
     </style>
+    <link rel="stylesheet" href="{% static 'frontend/baseball-data-lab-web.css' %}">
     {% block head %}{% endblock %}
 </head>
 <body>


### PR DESCRIPTION
## Summary
- always link to the compiled `baseball-data-lab-web.css` so PrimeIcons and other styles load when the Vite dev server isn't serving assets

## Testing
- `python backend/manage.py test` (no tests found)
- `npm test` (no test files found)


------
https://chatgpt.com/codex/tasks/task_e_68a91bbd47ac8326b46702b18ffbfffd