### PR TITLE
style: align schedule view with home

### DIFF
--- a/frontend/src/components/GameRow.vue
+++ b/frontend/src/components/GameRow.vue
@@ -3,7 +3,7 @@
     <div class="game-teams">
       <span
         class="team-chip away"
-        style="display:inline-flex;align-items:center;padding:2px 6px;margin-right:4px;background:#ffffff;"
+        style="display:inline-flex;align-items:center;padding:2px 6px;margin-right:4px;background:#ffffff;color:var(--color-primary);border-radius:4px;"
       >
         <img
           v-if="game.teams.away.team.logo_url"
@@ -16,7 +16,7 @@
       <span style="padding:0 4px;opacity:.6;font-size:1.0rem">@</span>
       <span
         class="team-chip home"
-        style="display:inline-flex;align-items:center;padding:2px 6px;margin-left:4px;background:#ffffff;"
+        style="display:inline-flex;align-items:center;padding:2px 6px;margin-left:4px;background:#ffffff;color:var(--color-primary);border-radius:4px;"
       >
         <img
           v-if="game.teams.home.team.logo_url"
@@ -76,17 +76,17 @@ const { game } = defineProps({
 });
 
 const rowStyle = {
-  background: '#f9fafb',
-  padding: '6px 10px',
-  border: '1px solid #e2e8f0',
+  background: 'rgba(255, 255, 255, 0.1)',
+  padding: '10px',
+  border: '1px solid rgba(255,255,255,0.2)',
   borderRadius: '6px',
-  marginLeft: 'auto',
   display: 'flex',
   alignItems: 'center',
   gap: '10px',
-  fontSize: '.75rem',
+  fontSize: '.85rem',
   lineHeight: '1.1',
-  boxShadow: '0 1px 2px rgba(0,0,0,0.04)'
+  color: '#fff',
+  boxShadow: '0 2px 4px rgba(0,0,0,0.1)'
 };
 </script>
 
@@ -94,8 +94,6 @@ const rowStyle = {
 .game-row {
   display: flex;
   align-items: center;
-  padding: 0.5rem 0;
-  border-bottom: 1px solid #eee;
 }
 
 .game-teams {
@@ -116,13 +114,13 @@ const rowStyle = {
 .game-broadcasts {
   flex: 1;
   font-size: 0.9rem;
-  color: #555;
+  color: rgba(255, 255, 255, 0.8);
 }
 
 .game-pitchers {
   width: 270px;
   font-size: 0.9rem;
-  color: #555;
+  color: rgba(255, 255, 255, 0.8);
   text-align: right;
 }
 

--- a/frontend/src/views/ScheduleView.vue
+++ b/frontend/src/views/ScheduleView.vue
@@ -1,22 +1,35 @@
 <template>
-  <div v-if="scheduleStore.schedule && scheduleStore.schedule.length">
-    <DataView :value="allGames" layout="list">
-      <template #header>
-        <div class="schedule-header">
-          <button class="nav-btn" @click="prevDay">&#8592;</button>
-          <h2 class="header-date">
-            {{ currentDate() === today ? `Today - ${formatDate(currentDate())}` : formatDate(currentDate()) }}
-          </h2>
-          <button class="nav-btn" @click="nextDay">&#8594;</button>
-        </div>
-      </template>
-      <template #list="slotProps">
-        <div class="game-list">
-          <GameRow v-for="game in slotProps.items" :key="game.gamePk" :game="game" />
-        </div>
-      </template>
-    </DataView>
-  </div>
+  <section class="schedule">
+    <div
+      class="schedule-container"
+      v-if="scheduleStore.schedule && scheduleStore.schedule.length"
+    >
+      <DataView :value="allGames" layout="list">
+        <template #header>
+          <div class="schedule-header">
+            <button class="nav-btn" @click="prevDay">&#8592;</button>
+            <h2 class="header-date">
+              {{
+                currentDate() === today
+                  ? `Today - ${formatDate(currentDate())}`
+                  : formatDate(currentDate())
+              }}
+            </h2>
+            <button class="nav-btn" @click="nextDay">&#8594;</button>
+          </div>
+        </template>
+        <template #list="slotProps">
+          <div class="game-list">
+            <GameRow
+              v-for="game in slotProps.items"
+              :key="game.gamePk"
+              :game="game"
+            />
+          </div>
+        </template>
+      </DataView>
+    </div>
+  </section>
 </template>
 
 <script setup>
@@ -98,14 +111,16 @@ onMounted(() => {
 </script>
 
 <style scoped>
-.schedule-day {
-  margin-bottom: 1.5rem;
+.schedule {
+  min-height: 100vh;
+  background: linear-gradient(135deg, var(--color-primary), var(--color-secondary));
+  color: #fff;
+  padding: 2rem 1rem;
 }
 
-.game-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
+.schedule-container {
+  max-width: 800px;
+  margin: 0 auto;
 }
 
 .schedule-header {
@@ -119,12 +134,35 @@ onMounted(() => {
   flex: 1;
   text-align: center;
   margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
 }
 
 .nav-btn {
-  background: none;
+  background-color: var(--color-accent);
+  color: var(--color-primary);
   border: none;
-  font-size: 1.25rem;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
+  transition: background-color 0.3s ease, transform 0.3s ease;
+}
+
+.nav-btn:hover {
+  background-color: #f59e0b;
+  transform: translateY(-2px);
+}
+
+.game-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 </style>


### PR DESCRIPTION
## Summary
- give ScheduleView a full-screen gradient background, centered container, and accent navigation buttons for day switching
- restyle GameRow entries with transparent cards and white text to match the HomeView aesthetic

## Testing
- `npm test` *(fails: No test files found)*
- `python manage.py test` *(fails: OperationalError: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a927b3f270832681340b493d077b7c