### PR TITLE
fix: improve GameRow text visibility

### DIFF
--- a/frontend/src/components/GameRow.vue
+++ b/frontend/src/components/GameRow.vue
@@ -85,7 +85,7 @@ const rowStyle = {
   gap: '10px',
   fontSize: '.85rem',
   lineHeight: '1.1',
-  color: '#fff',
+  color: '#000',
   boxShadow: '0 2px 4px rgba(0,0,0,0.1)'
 };
 </script>
@@ -114,13 +114,13 @@ const rowStyle = {
 .game-broadcasts {
   flex: 1;
   font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.8);
+  color: rgba(0, 0, 0, 0.8);
 }
 
 .game-pitchers {
   width: 270px;
   font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.8);
+  color: rgba(0, 0, 0, 0.8);
   text-align: right;
 }
 


### PR DESCRIPTION
## Summary
- use dark text colors in `GameRow` to make content visible on light backgrounds

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68a92c96815c832680e81dd01a4f32f0