### PR TITLE
refactor standings view layout

### DIFF
--- a/frontend/src/views/StandingsView.vue
+++ b/frontend/src/views/StandingsView.vue
@@ -1,43 +1,45 @@
 <template>
-  <div v-if="standingsStore.standings.length" style="font-family: proxima-nova, 'open Sans', Helvetica, Arial, sans-serif;">
-    <div v-for="(record, index) in standingsStore.standings" :key="index" class="division">
-      <h3>{{ getDivisionName(record.division?.id)  }}</h3>
-      <DataTable :value="record.teamRecords">
-        <Column field="team.name" header="Team" style="width:180px"></Column>
-        <Column field="wins" header="W"></Column>
-        <Column field="losses" header="L"></Column>
-        <Column field="winningPercentage" header="PCT"></Column>
-        <Column field="divisionGamesBack" header="GB"></Column>
-        <Column field="wildCardGamesBack" header="WCGB"></Column>
-        <Column field="runsScored" header="RS"></Column>
-        <Column field="runsAllowed" header="RA"></Column>
-        <Column field="runDifferential" header="rDiff"></Column>
-        <Column header="xWL">
-          <template #body="{ data }">
-            {{ `${data.records.expectedRecords[0].wins}-${data.records.expectedRecords[0].losses}` }}
-          </template>
-        </Column>
-        <Column header="Home">
-          <template #body="{ data }">
-            {{ `${data.records.splitRecords[0].wins} - ${data.records.splitRecords[0].losses}` }}
-          </template>
-        </Column>
-        <Column header="Away">
-          <template #body="{ data }">
-            {{ `${data.records.splitRecords[1].wins}-${data.records.splitRecords[1].losses}` }}
-          </template>
-        </Column>
-        <Column header="Division">
-          <template #body="{ data }">
-            {{ divisionRecord(data, record.division?.id) }}
-          </template>
-        </Column>
-      </DataTable>
+  <section class="standings">
+    <div v-if="standingsStore.standings.length">
+      <div v-for="(record, index) in standingsStore.standings" :key="index" class="division">
+        <h3>{{ getDivisionName(record.division?.id)  }}</h3>
+        <DataTable :value="record.teamRecords">
+          <Column field="team.name" header="Team" style="width:180px"></Column>
+          <Column field="wins" header="W"></Column>
+          <Column field="losses" header="L"></Column>
+          <Column field="winningPercentage" header="PCT"></Column>
+          <Column field="divisionGamesBack" header="GB"></Column>
+          <Column field="wildCardGamesBack" header="WCGB"></Column>
+          <Column field="runsScored" header="RS"></Column>
+          <Column field="runsAllowed" header="RA"></Column>
+          <Column field="runDifferential" header="rDiff"></Column>
+          <Column header="xWL">
+            <template #body="{ data }">
+              {{ `${data.records.expectedRecords[0].wins}-${data.records.expectedRecords[0].losses}` }}
+            </template>
+          </Column>
+          <Column header="Home">
+            <template #body="{ data }">
+              {{ `${data.records.splitRecords[0].wins} - ${data.records.splitRecords[0].losses}` }}
+            </template>
+          </Column>
+          <Column header="Away">
+            <template #body="{ data }">
+              {{ `${data.records.splitRecords[1].wins}-${data.records.splitRecords[1].losses}` }}
+            </template>
+          </Column>
+          <Column header="Division">
+            <template #body="{ data }">
+              {{ divisionRecord(data, record.division?.id) }}
+            </template>
+          </Column>
+        </DataTable>
+      </div>
     </div>
-  </div>
-  <div v-else>
-    <p>Standings data is loading.</p>
-  </div>
+    <div v-else>
+      <p>Standings data is loading.</p>
+    </div>
+  </section>
 </template>
 
 <script setup>
@@ -78,6 +80,10 @@ onMounted(() => {
 </script>
 
 <style scoped>
+.standings {
+  font-family: var(--font-base);
+}
+
 .division {
   margin-bottom: 2rem;
 }


### PR DESCRIPTION
## Summary
- wrap Standings view content in `<section class="standings">`
- move font settings to scoped CSS using `var(--font-base)`

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0ca960f4832691dd6249ecace142