### PR TITLE
Add division quick links in standings view

### DIFF
--- a/frontend/src/views/StandingsView.vue
+++ b/frontend/src/views/StandingsView.vue
@@ -2,7 +2,21 @@
   <section class="standings">
     <div class="standings-container">
       <div v-if="standingsStore.standings.length">
-        <div v-for="(record, index) in standingsStore.standings" :key="index" class="division-card">
+        <nav class="division-links">
+          <a
+            v-for="(record, index) in standingsStore.standings"
+            :key="`link-${index}`"
+            :href="`#division-${record.division?.id}`"
+          >
+            {{ getDivisionName(record.division?.id) }}
+          </a>
+        </nav>
+        <div
+          v-for="(record, index) in standingsStore.standings"
+          :key="index"
+          class="division-card"
+          :id="`division-${record.division?.id}`"
+        >
           <h3>{{ getDivisionName(record.division?.id)  }}</h3>
           <DataTable class="standings-table" :value="record.teamRecords" responsiveLayout="scroll">
             <Column field="team.name" header="Team" style="width:180px"></Column>
@@ -96,11 +110,25 @@ onMounted(() => {
   background: linear-gradient(135deg, var(--color-primary), var(--color-secondary));
   color: #fff;
   padding: 2rem 1rem;
+  scroll-behavior: smooth;
 }
 
 .standings-container {
   max-width: 1000px;
   margin: 0 auto;
+}
+
+.division-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.division-links a {
+  color: var(--color-accent);
+  text-decoration: underline;
 }
 .division-card {
   background: rgba(255, 255, 255, 0.15);


### PR DESCRIPTION
## Summary
- add navigation links at top of StandingsView for each division
- assign ids to division cards and style link bar for quick scrolling

## Testing
- `npm test -- --passWithNoTests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa11c5d89483269029f072682203be