### PR TITLE
style(players): match schedule page layout

### DIFF
--- a/frontend/src/views/PlayersView.vue
+++ b/frontend/src/views/PlayersView.vue
@@ -1,13 +1,15 @@
 <template>
-  <div>
-    <h1>Players</h1>
-    <SearchAutocomplete
-      placeholder="Search for a player"
-      optionLabel="name_full"
-      searchEndpoint="/api/players/"
-      routeName="Player"
-    />
-  </div>
+  <section class="search-page players-view">
+    <div class="search-container">
+      <h1>Players</h1>
+      <SearchAutocomplete
+        placeholder="Search for a player"
+        optionLabel="name_full"
+        searchEndpoint="/api/players/"
+        routeName="Player"
+      />
+    </div>
+  </section>
 </template>
 
 <script setup>
@@ -15,5 +17,31 @@ import SearchAutocomplete from '../components/SearchAutocomplete.vue';
 </script>
 
 <style scoped>
+.search-page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, var(--color-primary), var(--color-secondary));
+  color: #fff;
+  padding: 2rem 1rem;
+}
+
+.search-container {
+  max-width: 600px;
+  width: 100%;
+  text-align: center;
+}
+
+.search-container h1 {
+  font-size: 2rem;
+  margin: 0 0 1rem;
+  font-weight: 600;
+}
+
+.search-container :deep(.p-autocomplete),
+.search-container :deep(.p-autocomplete input) {
+  width: 100%;
+}
 </style>
 


### PR DESCRIPTION
## Summary
- Rework PlayersView layout to match schedule page styling with gradient background and centered container
- Add scoped styles for search page, container, heading and full-width autocomplete input

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa11d2b1ec8326b210004e4e26547c