### PR TITLE
Fix TeamView logo and record loading

### DIFF
--- a/frontend/src/views/TeamView.vue
+++ b/frontend/src/views/TeamView.vue
@@ -77,6 +77,7 @@ const { id, name } = defineProps({
 const teamLogoSrc = ref("");
 const teamRecord = ref(null);
 const recentSchedule = ref(null);
+const mlbamTeamId = computed(() => recentSchedule.value?.id);
 
 // fetcher for plain-text URL
 async function loadLogo(teamId) {
@@ -104,16 +105,30 @@ async function loadRecord(teamId) {
 
 
 onMounted(() => {
-  loadLogo(id);
-  loadRecord(id);
   loadRecentSchedule(id);
 });
 
-watch(() => id, (newId) => {
-  loadLogo(newId);
-  loadRecord(newId);
-  loadRecentSchedule(newId);
-});
+watch(
+  () => id,
+  (newId) => {
+    teamLogoSrc.value = "";
+    teamRecord.value = null;
+    loadRecentSchedule(newId);
+  }
+);
+
+watch(
+  () => mlbamTeamId.value,
+  (newId) => {
+    if (newId) {
+      loadLogo(newId);
+      loadRecord(newId);
+    } else {
+      teamLogoSrc.value = "";
+      teamRecord.value = null;
+    }
+  }
+);
 
 function formatRank(rank) {
   if (rank == null) return "";
@@ -145,8 +160,6 @@ const nextGames = computed(() => {
   const dates = recentSchedule.value?.nextGameSchedule?.dates ?? [];
   return dates.flatMap(d => d.games);
 });
-
-const mlbamTeamId = computed(() => recentSchedule.value?.id);
 
 const streakCode = computed(() => teamRecord.value?.streak?.streakCode || "");
 


### PR DESCRIPTION
## Summary
- Correct TeamView to load team logo and record using MLBAM team id
- Reset and reload team data when route id changes

## Testing
- `npm test` (fails: No test files found)
- `python manage.py test` (fails: connection to PostgreSQL at localhost:5432 refused)


------
https://chatgpt.com/codex/tasks/task_e_68aa15797fbc8326912c35781182b7ec