### PR TITLE
refactor: centralize search page styles

### DIFF
--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -33,22 +33,22 @@ a:hover {
   padding: 2rem 1rem;
 }
 
-.search-container {
+.search-page .search-container {
   text-align: center;
 }
 
-.search-container h1 {
+.search-page .search-container h1 {
   font-size: 2rem;
   font-weight: 700;
   margin-bottom: 1rem;
 }
 
-.search-container .p-autocomplete {
+.search-page .search-container .p-autocomplete {
   width: 100%;
   max-width: 400px;
   margin: 0 auto;
 }
 
-.search-container .p-inputtext {
+.search-page .search-container .p-inputtext {
   width: 100%;
 }

--- a/frontend/src/views/PlayersView.vue
+++ b/frontend/src/views/PlayersView.vue
@@ -16,33 +16,4 @@
 import SearchAutocomplete from '../components/SearchAutocomplete.vue';
 </script>
 
-<style scoped>
-.search-page {
-  min-height: 100vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: linear-gradient(135deg, var(--color-primary), var(--color-secondary));
-  color: #fff;
-  padding: 2rem 1rem;
-}
-
-.search-container {
-  max-width: 600px;
-  width: 100%;
-  text-align: center;
-}
-
-.search-container h1 {
-  font-size: 2rem;
-  margin: 0 0 1rem;
-  font-weight: 600;
-}
-
-.search-container :deep(.p-autocomplete),
-.search-container :deep(.p-autocomplete input) {
-  width: 100%;
-}
-</style>
-
 


### PR DESCRIPTION
## Summary
- consolidate search page and container styles in global stylesheet
- remove PlayersView scoped style block and rely on global classes

## Testing
- `npm test` (fails: No test files found)

------
https://chatgpt.com/codex/tasks/task_e_68aa1b8682dc8326972a29f760d81cc6