### PR TITLE
Optimize GameRow data fetching

### DIFF
--- a/frontend/src/components/GameRow.vue
+++ b/frontend/src/components/GameRow.vue
@@ -171,10 +171,19 @@ async function fetchTeamStreak(teamId) {
 }
 
 onMounted(async () => {
-  awayRecord.value = await fetchTeamRecord(game.teams.away.team.id);
-  homeRecord.value = await fetchTeamRecord(game.teams.home.team.id);
-  awayStreak.value = await fetchTeamStreak(game.teams.away.team.id);
-  homeStreak.value = await fetchTeamStreak(game.teams.home.team.id);
+  const [
+    awayRecordRes, homeRecordRes,
+    awayStreakRes, homeStreakRes
+  ] = await Promise.all([
+    fetchTeamRecord(game.teams.away.team.id),
+    fetchTeamRecord(game.teams.home.team.id),
+    fetchTeamStreak(game.teams.away.team.id),
+    fetchTeamStreak(game.teams.home.team.id)
+  ]);
+  awayRecord.value = awayRecordRes;
+  homeRecord.value = homeRecordRes;
+  awayStreak.value = awayStreakRes;
+  homeStreak.value = homeStreakRes;
 });
 
 const rowStyle = {


### PR DESCRIPTION
## Summary
- fetch team records and streaks concurrently in GameRow

## Testing
- `npm test` *(fails: No test files found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68aa264c075083268091755d9bec9ec0