### PR TITLE
Remove virtual scroller from schedule view

### DIFF
--- a/frontend/src/views/ScheduleView.vue
+++ b/frontend/src/views/ScheduleView.vue
@@ -9,15 +9,13 @@
         <h2 class="header-date">{{ headerDate }}</h2>
         <button class="nav-btn" @click="nextDay">&#8594;</button>
       </div>
-      <VirtualScroller
-        :items="allGames"
-        :itemSize="110"
-        scrollHeight="70vh"
-      >
-        <template #item="{ item }">
-          <GameRow :key="item.gamePk" :game="item" />
-        </template>
-      </VirtualScroller>
+      <div class="games-list">
+        <GameRow
+          v-for="game in allGames"
+          :key="game.gamePk"
+          :game="game"
+        />
+      </div>
     </div>
   </section>
 </template>
@@ -219,7 +217,7 @@ onMounted(() => {
   transform: translateY(-2px);
 }
 
-:deep(.p-virtualscroller-content) {
+.games-list {
   list-style: none;
   padding: 0;
   margin: 0;


### PR DESCRIPTION
## Summary
- replace ScheduleView virtual scroller with simple game list
- clean up styles tied to virtual scrolling

## Testing
- `npm test` *(fails: No test files found)*
- `python manage.py test` *(fails: connection to PostgreSQL at localhost:5432 refused)*

------
https://chatgpt.com/codex/tasks/task_e_68aa29cce930832696a629d348aad52b