### PR TITLE
Link standings team names to team view

### DIFF
--- a/frontend/src/views/StandingsView.vue
+++ b/frontend/src/views/StandingsView.vue
@@ -30,7 +30,19 @@
         >
           <h3>{{ getDivisionName(record.division?.id)  }}</h3>
           <DataTable class="standings-table" :value="record.teamRecords" responsiveLayout="scroll">
-            <Column field="team.name" header="Team" style="width:180px"></Column>
+            <Column header="Team" style="width:180px">
+              <template #body="{ data }">
+                <RouterLink
+                  :to="{
+                    name: 'Team',
+                    params: { id: data.team.id },
+                    query: { name: data.team.name }
+                  }"
+                >
+                  {{ data.team.name }}
+                </RouterLink>
+              </template>
+            </Column>
             <Column field="wins" header="W"></Column>
             <Column field="losses" header="L"></Column>
             <Column field="winningPercentage" header="PCT"></Column>


### PR DESCRIPTION
## Summary
- Link each team name in standings to the Team view for that team

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*
- `npm test` *(fails: No test files found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68aa354503e88326bfcfa7093a5339fa