### PR TITLE
Group standings by league for StandingsView

### DIFF
--- a/frontend/src/store/standings.js
+++ b/frontend/src/store/standings.js
@@ -2,6 +2,10 @@ import { defineStore } from 'pinia';
 
 export const useStandingsStore = defineStore('standings', {
   state: () => ({
-    standings: []
+    standings: [],
+    standingsByLeague: {
+      al: [],
+      nl: []
+    }
   })
 });


### PR DESCRIPTION
## Summary
- Preprocess standings to group divisions by league in StandingsView
- Store grouped standings in Pinia store
- Iterate over grouped league standings in template

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa37ae02f0832685cfca3cae33c80c