### PR TITLE
Use shallowRef to track schedule games

### DIFF
--- a/frontend/src/views/ScheduleView.vue
+++ b/frontend/src/views/ScheduleView.vue
@@ -11,7 +11,7 @@
       </div>
       <div class="games-list">
         <GameRow
-          v-for="game in allGames"
+          v-for="game in games"
           :key="game.gamePk"
           :game="game"
         />
@@ -21,7 +21,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted } from 'vue';
+import { computed, onMounted, shallowRef, watch } from 'vue';
 import { useScheduleStore } from '../store/schedule';
 import GameRow from '../components/GameRow.vue';
 
@@ -42,9 +42,14 @@ const nyHourFormatter = new Intl.DateTimeFormat('en-US', {
   hour12: false
 });
 
+const games = shallowRef([]);
 
-const allGames = computed(() =>
-  scheduleStore.schedule.flatMap((d) => d.games || [])
+watch(
+  () => scheduleStore.schedule,
+  (schedule) => {
+    games.value = schedule.flatMap((d) => d.games || []);
+  },
+  { immediate: true }
 );
 
 const currentDate = computed(() => {


### PR DESCRIPTION
## Summary
- replace `allGames` computed property with `games` shallowRef
- watch schedule store to update `games`
- render `<GameRow>` using `games`

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa37bdad34832686883c0c1932fb92