### PR TITLE
Fix TeamView data loading from standings links

### DIFF
--- a/frontend/src/views/TeamView.vue
+++ b/frontend/src/views/TeamView.vue
@@ -85,6 +85,7 @@ const { id, name } = defineProps({
 const teamLogoSrc = ref("");
 const teamRecord = ref(null);
 const recentSchedule = ref(null);
+const internalTeamId = ref(null);
 const mlbamTeamId = computed(() => recentSchedule.value?.id);
 
 // fetcher for plain-text URL
@@ -112,8 +113,23 @@ async function loadRecord(teamId) {
 }
 
 
+async function resolveTeamId(teamId) {
+  try {
+    const resp = await fetch(`/api/teams/${teamId}/`);
+    if (resp.ok) {
+      const data = await resp.json();
+      internalTeamId.value = data.id;
+    } else {
+      internalTeamId.value = teamId;
+    }
+  } catch (e) {
+    internalTeamId.value = teamId;
+  }
+  await loadRecentSchedule(internalTeamId.value);
+}
+
 onMounted(() => {
-  loadRecentSchedule(id);
+  resolveTeamId(id);
 });
 
 watch(
@@ -121,7 +137,9 @@ watch(
   (newId) => {
     teamLogoSrc.value = "";
     teamRecord.value = null;
-    loadRecentSchedule(newId);
+    recentSchedule.value = null;
+    internalTeamId.value = null;
+    resolveTeamId(newId);
   }
 );
 


### PR DESCRIPTION
## Summary
- resolve team links that supply MLBAM ids by looking up internal team ids
- reset and reload team data on route changes so TeamView populates correctly

## Testing
- `npm test` *(fails: No test files found)*
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3853710c8326a5d09bf749929cc5