### PR TITLE
Use division IDs as v-for keys in standings view

### DIFF
--- a/frontend/src/views/StandingsView.vue
+++ b/frontend/src/views/StandingsView.vue
@@ -5,8 +5,8 @@
         <nav class="division-links">
           <div class="league-row">
             <a
-              v-for="(record, index) in standingsStore.standingsByLeague.al"
-              :key="`al-link-${index}`"
+              v-for="record in standingsStore.standingsByLeague.al"
+              :key="record.division?.id"
               :href="`#division-${record.division?.id}`"
             >
               {{ getDivisionName(record.division?.id) }}
@@ -14,8 +14,8 @@
           </div>
           <div class="league-row">
             <a
-              v-for="(record, index) in standingsStore.standingsByLeague.nl"
-              :key="`nl-link-${index}`"
+              v-for="record in standingsStore.standingsByLeague.nl"
+              :key="record.division?.id"
               :href="`#division-${record.division?.id}`"
             >
               {{ getDivisionName(record.division?.id) }}
@@ -23,8 +23,8 @@
           </div>
         </nav>
         <div
-          v-for="(record, index) in standingsStore.standings"
-          :key="index"
+          v-for="record in standingsStore.standings"
+          :key="record.division?.id"
           class="division-card"
           :id="`division-${record.division?.id}`"
         >


### PR DESCRIPTION
## Summary
- Key standings navigation and division cards by their division IDs to ensure unique anchors and stable rendering

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa38d58b9c8326a79a16ac4c58ff65