### PR TITLE
Load GameRow component asynchronously

### DIFF
--- a/frontend/src/views/ScheduleView.vue
+++ b/frontend/src/views/ScheduleView.vue
@@ -21,9 +21,18 @@
 </template>
 
 <script setup>
-import { computed, onMounted, shallowRef, watch } from 'vue';
+import {
+  computed,
+  onMounted,
+  shallowRef,
+  watch,
+  defineAsyncComponent
+} from 'vue';
 import { useScheduleStore } from '../store/schedule';
-import GameRow from '../components/GameRow.vue';
+
+const GameRow = defineAsyncComponent(() =>
+  import('../components/GameRow.vue')
+);
 
 const scheduleStore = useScheduleStore();
 


### PR DESCRIPTION
## Summary
- Lazy-load GameRow component in ScheduleView using defineAsyncComponent

## Testing
- `npm test` (fails: No test files found, exiting with code 1)


------
https://chatgpt.com/codex/tasks/task_e_68aa3ab6fc948326886117c9229fee17