### PR TITLE
Improve ScheduleView game row contrast

### DIFF
--- a/frontend/src/components/GameRow.vue
+++ b/frontend/src/components/GameRow.vue
@@ -124,9 +124,9 @@ onMounted(async () => {
 });
 
 const rowStyle = {
-  background: 'rgba(255, 255, 255, 0.1)',
+  background: '#ffffff',
   padding: '10px',
-  border: '1px solid rgba(255,255,255,0.2)',
+  border: '1px solid rgba(0,0,0,0.1)',
   borderRadius: '6px',
   display: 'flex',
   alignItems: 'center',


### PR DESCRIPTION
## Summary
- improve visibility of game rows on ScheduleView by using a white background and subtle border

## Testing
- `python backend/manage.py test`
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3b73828483269ea71f93b40223b5