### PR TITLE
Fix schedule store reactivity

### DIFF
--- a/frontend/src/store/schedule.js
+++ b/frontend/src/store/schedule.js
@@ -1,13 +1,18 @@
 import { defineStore } from 'pinia';
 import { shallowRef } from 'vue';
 
-export const useScheduleStore = defineStore('schedule', {
-  state: () => ({
-    schedule: shallowRef([])
-  }),
-  actions: {
-    setSchedule(data) {
-      this.schedule.value = data;
-    }
+// Using the setup-style store ensures the `schedule` remains a ref. When
+// `shallowRef` was used directly in the state of an options store, Pinia
+// unwrapped it, causing it to lose its ref behavior. Components that watched
+// the schedule then received a plain array and Vue reported "Invalid watch
+// source" errors. Exposing a ref from the setup store keeps it reactive and
+// avoids those errors.
+export const useScheduleStore = defineStore('schedule', () => {
+  const schedule = shallowRef([]);
+
+  function setSchedule(data) {
+    schedule.value = data;
   }
+
+  return { schedule, setSchedule };
 });

--- a/frontend/src/views/ScheduleView.vue
+++ b/frontend/src/views/ScheduleView.vue
@@ -66,7 +66,9 @@ watch(
 const currentDate = computed(() => {
   const dateStr =
     scheduleStore.schedule.value[0]?.date ||
-    scheduleStore.schedule.value[0]?.games[0]?.gameDate;
+    // Use optional chaining for array access to avoid errors when the
+    // schedule array is empty.
+    scheduleStore.schedule.value[0]?.games?.[0]?.gameDate;
   return dateStr ? dateStr.slice(0, 10) : today;
 });
 


### PR DESCRIPTION
## Summary
- Convert schedule Pinia store to setup-style to retain shallowRef
- Guard schedule access in ScheduleView with optional chaining

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3fcb3c108326a558191a77c6e22e