### PR TITLE
Fix ScheduleView games mapping for undefined days

### DIFF
--- a/frontend/src/views/ScheduleView.vue
+++ b/frontend/src/views/ScheduleView.vue
@@ -58,7 +58,9 @@ const games = shallowRef([]);
 watch(
   scheduleStore.schedule,
   (schedule) => {
-    games.value = schedule.flatMap((d) => d.games || []);
+    games.value = Array.isArray(schedule)
+      ? schedule.flatMap((d) => d?.games || [])
+      : [];
   },
   { immediate: true }
 );


### PR DESCRIPTION
## Summary
- Avoid TypeError when some schedule entries are undefined by guarding and optional chaining

## Testing
- `npm test --prefix frontend` (fails: No test files found, exiting with code 1)
- `python backend/manage.py test` (fails: Ran 0 tests)


------
https://chatgpt.com/codex/tasks/task_e_68aa40fc37708326b0c36da3ca545026