### PR TITLE
Fix team logo loading on TeamView

### DIFF
--- a/frontend/src/views/TeamView.vue
+++ b/frontend/src/views/TeamView.vue
@@ -178,7 +178,10 @@ watch(
   () => mlbamTeamId.value,
   (newId) => {
     if (newId) {
-      loadLogo(newId);
+      // team_logo expects the internal team ID, whereas team_record
+      // expects the MLBAM team ID. Use the appropriate identifier for
+      // each API call.
+      loadLogo(internalTeamId.value);
       loadRecord(newId);
     } else {
       teamLogoSrc.value = "";


### PR DESCRIPTION
## Summary
- ensure TeamView fetches team logos using internal team ID

## Testing
- `python manage.py test` (fails: connection refused to PostgreSQL)
- `npm test` (fails: No test files found)


------
https://chatgpt.com/codex/tasks/task_e_68aa4666066c8326a8fef08818439dab