### PR TITLE
Add player info API and display team details in player view

### DIFF
--- a/backend/apps/api/tests.py
+++ b/backend/apps/api/tests.py
@@ -133,6 +133,33 @@ class PlayerHeadshotApiTests(TestCase):
         mock_client.fetch_player_headshot.assert_called_once_with(456)
 
 
+class PlayerInfoApiTests(TestCase):
+    @patch('apps.api.views.UnifiedDataClient')
+    def test_player_info_endpoint(self, mock_client_cls):
+        mock_client = mock_client_cls.return_value
+        mock_client.fetch_player_info.return_value = {
+            'currentTeam': {'id': 111, 'name': 'Team A'},
+            'primaryPosition': {'name': 'Pitcher'},
+        }
+
+        PlayerIdInfo.objects.create(
+            id=1,
+            key_mlbam='123',
+            name_first='Test',
+            name_last='Player',
+        )
+
+        client = Client()
+        response = client.get('/api/players/1/')
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data['team_id'], 111)
+        self.assertEqual(data['team_name'], 'Team A')
+        self.assertEqual(data['position'], 'Pitcher')
+        mock_client.fetch_player_info.assert_called_once_with(123)
+
+
 class PlayerSearchApiTests(TestCase):
     def setUp(self):
         # Create more than 10 players to ensure the limit works

--- a/backend/apps/api/urls.py
+++ b/backend/apps/api/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     path('standings/', views.standings, name='api-standings'),
     path('news/', views.news, name='api-news'),
     path('players/', views.player_search, name='api-player-search'),
+    path('players/<int:player_id>/', views.player_info, name='api-player-info'),
     path('player/<int:player_id>/headshot/', views.player_headshot, name='api-player-headshot'),
     path('teams/', views.team_search, name='api-team-search'),
     path('teams/<int:mlbam_team_id>/', views.team_info, name='api-team-info'),

--- a/frontend/src/views/PlayerView.vue
+++ b/frontend/src/views/PlayerView.vue
@@ -1,13 +1,23 @@
 <template>
   <div>
     <h1>{{ name }}</h1>
-    <img v-if="headshotSrc" :src="headshotSrc" alt="Player headshot" />
+    <div v-if="teamName" class="team-info">
+      <img
+        v-if="teamLogoSrc"
+        :src="teamLogoSrc"
+        alt="Team logo"
+        class="team-logo"
+      />
+      <span>{{ teamName }}</span>
+    </div>
+    <p v-if="position">{{ position }}</p>
+    <img v-if="headshotSrc" :src="headshotSrc" alt="Player headshot" class="headshot" />
     <p>ID: {{ id }}</p>
   </div>
 </template>
 
 <script setup>
-import { computed } from 'vue';
+import { ref, computed, onMounted } from 'vue';
 
 const { id, name } = defineProps({
   id: String,
@@ -15,10 +25,46 @@ const { id, name } = defineProps({
 });
 
 const headshotSrc = computed(() => `/api/player/${id}/headshot/`);
+const teamName = ref('');
+const position = ref('');
+const teamLogoSrc = ref('');
+
+onMounted(async () => {
+  try {
+    const resp = await fetch(`/api/players/${id}/`);
+    if (resp.ok) {
+      const data = await resp.json();
+      teamName.value = data.team_name || '';
+      position.value = data.position || '';
+      if (data.team_id) {
+        try {
+          const logoResp = await fetch(`/api/teams/${data.team_id}/logo/`);
+          if (logoResp.ok) {
+            teamLogoSrc.value = (await logoResp.text()).trim();
+          }
+        } catch (e) {
+          console.error('Failed to fetch team logo', e);
+        }
+      }
+    }
+  } catch (e) {
+    console.error('Failed to load player info', e);
+  }
+});
 </script>
 
 <style scoped>
-img {
+.headshot {
   max-width: 200px;
+}
+.team-logo {
+  width: 40px;
+  height: 40px;
+  margin-right: 8px;
+}
+.team-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 </style>


### PR DESCRIPTION
## Summary
- add `player_info` API view to return a player's team and position
- expose new `players/<id>/` endpoint and hook up frontend PlayerView
- show team logo and position when viewing a player

## Testing
- `python manage.py test` *(fails: OperationalError: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*
- `npm test` *(fails: No test files found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68aa53b2258083268e16fa97f8a8ad75