### PR TITLE
Split team roster into batter and pitcher sections

### DIFF
--- a/frontend/src/views/TeamView.vue
+++ b/frontend/src/views/TeamView.vue
@@ -44,8 +44,8 @@
         </table>
       </div>
 
-      <div v-if="roster.length" class="stats-container">
-        <h2>Roster</h2>
+      <div v-if="batters.length" class="stats-container">
+        <h2>Batters</h2>
         <table class="team-stats">
           <thead>
             <tr>
@@ -53,11 +53,10 @@
               <th>Pos</th>
               <th>G</th>
               <th>AVG</th>
-              <th>ERA</th>
             </tr>
           </thead>
           <tbody>
-            <tr v-for="player in roster" :key="player.person.id">
+            <tr v-for="player in batters" :key="player.person.id">
               <td>
                 <RouterLink :to="{ name: 'Player', params: { id: player.personid } }">
                   {{ player.person.fullName }}
@@ -66,6 +65,29 @@
               <td>{{ player.position.abbreviation }}</td>
               <td>{{ player.stats?.gamesPlayed ?? '' }}</td>
               <td>{{ player.stats?.avg ?? '' }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div v-if="pitchers.length" class="stats-container">
+        <h2>Pitchers</h2>
+        <table class="team-stats">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>G</th>
+              <th>ERA</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="player in pitchers" :key="player.person.id">
+              <td>
+                <RouterLink :to="{ name: 'Player', params: { id: player.personid } }">
+                  {{ player.person.fullName }}
+                </RouterLink>
+              </td>
+              <td>{{ player.stats?.gamesPlayed ?? '' }}</td>
               <td>{{ player.stats?.era ?? '' }}</td>
             </tr>
           </tbody>
@@ -248,6 +270,14 @@ const lastThirty = computed(() => {
 const runsScored = computed(() => teamRecord.value?.runsScored ?? "");
 const runsAllowed = computed(() => teamRecord.value?.runsAllowed ?? "");
 const runDifferential = computed(() => teamRecord.value?.runDifferential ?? "");
+
+const batters = computed(() =>
+  roster.value.filter(p => p.position?.abbreviation !== 'P')
+);
+
+const pitchers = computed(() =>
+  roster.value.filter(p => p.position?.abbreviation === 'P')
+);
 
 function formatDate(dateStr) {
   const d = new Date(dateStr);


### PR DESCRIPTION
## Summary
- split TeamView roster into separate Batters and Pitchers tables
- compute batter and pitcher groups from roster data

## Testing
- `npm test --prefix frontend` *(fails: No test files found)*
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*
- `npm run build --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68aa57daad308326a78b4c1bede13c24