### PR TITLE
Add player statistics endpoint and frontend component

### DIFF
--- a/backend/apps/api/urls.py
+++ b/backend/apps/api/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     path('news/', views.news, name='api-news'),
     path('players/', views.player_search, name='api-player-search'),
     path('players/<int:player_id>/', views.player_info, name='api-player-info'),
+    path('players/<int:player_id>/stats/', views.player_stats, name='api-player-stats'),
     path('player/<int:player_id>/headshot/', views.player_headshot, name='api-player-headshot'),
     path('teams/', views.team_search, name='api-team-search'),
     path('teams/<int:mlbam_team_id>/', views.team_info, name='api-team-info'),

--- a/frontend/src/components/PlayerStats.vue
+++ b/frontend/src/components/PlayerStats.vue
@@ -1,0 +1,111 @@
+<template>
+  <div class="player-stats" v-if="stats">
+    <div v-if="hittingRows.length">
+      <h2>Hitting</h2>
+      <table class="stats-table">
+        <thead>
+          <tr>
+            <th>Split</th>
+            <th v-for="field in hittingFields" :key="field">{{ field }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="row in hittingRows" :key="row.label">
+            <td>{{ row.label }}</td>
+            <td v-for="field in hittingFields" :key="field">{{ row[field] ?? '-' }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div v-if="pitchingRows.length">
+      <h2>Pitching</h2>
+      <table class="stats-table">
+        <thead>
+          <tr>
+            <th>Split</th>
+            <th v-for="field in pitchingFields" :key="field">{{ field }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="row in pitchingRows" :key="row.label">
+            <td>{{ row.label }}</td>
+            <td v-for="field in pitchingFields" :key="field">{{ row[field] ?? '-' }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, computed } from 'vue';
+
+const { id } = defineProps({ id: String });
+
+const stats = ref(null);
+
+onMounted(async () => {
+  try {
+    const resp = await fetch(`/api/players/${id}/stats/`);
+    if (resp.ok) {
+      stats.value = await resp.json();
+    }
+  } catch (e) {
+    console.error('Failed to fetch player stats', e);
+  }
+});
+
+const hittingFields = ['avg', 'homeRuns', 'rbi'];
+const pitchingFields = ['era', 'strikeOuts', 'wins', 'losses'];
+
+function buildRows(seasonStats, careerStats, fields) {
+  const rows = [];
+  if (seasonStats) {
+    for (const teamId of seasonStats.team_ids || []) {
+      const team = seasonStats.teams[teamId];
+      const row = { label: team.teamName };
+      fields.forEach(f => { row[f] = team.stats?.[f]; });
+      rows.push(row);
+    }
+    if (seasonStats.season && Object.keys(seasonStats.season).length) {
+      const totalRow = { label: 'Total' };
+      fields.forEach(f => { totalRow[f] = seasonStats.season[f]; });
+      rows.push(totalRow);
+    }
+  }
+  if (careerStats && careerStats.season && Object.keys(careerStats.season).length) {
+    const careerRow = { label: 'Career' };
+    fields.forEach(f => { careerRow[f] = careerStats.season[f]; });
+    rows.push(careerRow);
+  }
+  return rows;
+}
+
+const hittingRows = computed(() =>
+  buildRows(stats.value?.season?.batting, stats.value?.career?.batting, hittingFields)
+);
+const pitchingRows = computed(() =>
+  buildRows(stats.value?.season?.pitching, stats.value?.career?.pitching, pitchingFields)
+);
+</script>
+
+<style scoped>
+.player-stats {
+  margin-top: 2rem;
+}
+.stats-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1.5rem;
+}
+.stats-table th,
+.stats-table td {
+  padding: 0.5rem;
+  border: 1px solid rgba(0,0,0,0.1);
+  text-align: center;
+}
+.stats-table th {
+  background: rgba(0,0,0,0.05);
+}
+</style>
+

--- a/frontend/src/views/PlayerView.vue
+++ b/frontend/src/views/PlayerView.vue
@@ -26,12 +26,14 @@
       <div class="player-details">
         <p class="player-id">ID: {{ id }}</p>
       </div>
+      <PlayerStats :id="id" />
     </div>
   </section>
 </template>
 
 <script setup>
 import { ref, computed, onMounted } from 'vue';
+import PlayerStats from '../components/PlayerStats.vue';
 
 const { id } = defineProps({
   id: String


### PR DESCRIPTION
## Summary
- add player_stats API endpoint returning season and career data
- expose `/api/players/<id>/stats/` route
- create PlayerStats Vue component and render in player view

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa94d710a48326a2bd70eb972ca167