### PR TITLE
Prefetch adjacent schedule data concurrently

### DIFF
--- a/frontend/src/views/ScheduleView.vue
+++ b/frontend/src/views/ScheduleView.vue
@@ -99,13 +99,14 @@ async function fetchSchedule(
     return cached;
   }
 
+  if (prefetch && !cacheOnly) prefetchAdjacent(dateStr);
+
   const options = {};
   if (!cacheOnly) options.signal = controller.signal;
   const resp = await fetch(`/api/schedule/?date=${dateStr}`, options);
   const data = await resp.json();
   scheduleCache.set(dateStr, data);
   if (!cacheOnly) scheduleStore.setSchedule(data);
-  if (prefetch && !cacheOnly) prefetchAdjacent(dateStr);
 
   // Fetch win probability predictions for each game in parallel
   // const predictionPromises = [];


### PR DESCRIPTION
## Summary
- Prefetch adjacent days before schedule fetch completes to reduce delay when changing dates

## Testing
- `npm test` *(fails: No test files found)*
- `python manage.py test` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68aa957c25e883269df1fcf7697b0c17