### PR TITLE
Add tabbed layout to PlayerView

### DIFF
--- a/frontend/src/views/PlayerView.vue
+++ b/frontend/src/views/PlayerView.vue
@@ -23,7 +23,17 @@
         </div>
       </div>
 
-      <PlayerStats :id="id" />
+      <TabView>
+        <TabPanel header="Overview">
+          <p>Overview content coming soon.</p>
+        </TabPanel>
+        <TabPanel header="Stats">
+          <PlayerStats :id="id" />
+        </TabPanel>
+        <TabPanel header="Charts & Trends">
+          <p>Charts & Trends coming soon.</p>
+        </TabPanel>
+      </TabView>
     </div>
   </section>
 </template>
@@ -31,6 +41,8 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue';
 import PlayerStats from '../components/PlayerStats.vue';
+import TabView from 'primevue/tabview';
+import TabPanel from 'primevue/tabpanel';
 
 const { id } = defineProps({
   id: String


### PR DESCRIPTION
## Summary
- Add PrimeVue TabView to PlayerView for switching between Overview, Stats, and Charts & Trends sections
- Move PlayerStats into Stats tab and add placeholders for Overview and Charts & Trends

## Testing
- `npm test` *(fails: No test files found, exiting with code 1)*
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68ab60d0db148326901c13c2be5aa2cd