### PR TITLE
feat: add player team color styling

### DIFF
--- a/frontend/src/views/PlayerView.vue
+++ b/frontend/src/views/PlayerView.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="player-view">
+  <section class="player-view" :style="teamColorStyle">
     <div class="player-container">
       <div class="player-header">
         <img
@@ -43,6 +43,7 @@ import { ref, computed, onMounted } from 'vue';
 import PlayerStats from '../components/PlayerStats.vue';
 import TabView from 'primevue/tabview';
 import TabPanel from 'primevue/tabpanel';
+import teamColors from '../data/teamColors.json';
 
 const { id } = defineProps({
   id: String
@@ -53,6 +54,15 @@ const name = ref('');
 const teamName = ref('');
 const position = ref('');
 const teamLogoSrc = ref('');
+
+const teamColorStyle = computed(() => {
+  const colors = teamColors[teamName.value] || [];
+  return {
+    '--color-primary': colors[0]?.hex || '#1e3a8a',
+    '--color-secondary': colors[1]?.hex || '#1e40af',
+    '--color-accent': colors[2]?.hex || '#fbbf24'
+  };
+});
 
 onMounted(async () => {
   try {


### PR DESCRIPTION
## Summary
- add team color style binding to PlayerView root
- compute player team colors using existing team color data

## Testing
- `npm test` *(fails: No test files found)*
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68ab708e276483268422b4492e049432