### PR TITLE
Display schedule preview in two columns

### DIFF
--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -228,9 +228,19 @@ onMounted(async () => {
   margin: 0;
 }
 
+.schedule-preview ul {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.25rem 1rem;
+}
+
 .schedule-preview li,
 .standings-preview li {
   margin-bottom: 0.25rem;
+}
+
+.schedule-preview li {
+  margin-bottom: 0;
 }
 
 .logo-container {


### PR DESCRIPTION
## Summary
- show schedule preview games in two-column layout on home page

## Testing
- `npm test` *(fails: No test files found, exiting with code 1)*
- `python backend/manage.py test` *(fails: connection to server at "localhost" (127.0.0.1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7222bfe083268e3b76090b2fcb47