### PR TITLE
Add player biography section and API fields

### DIFF
--- a/backend/apps/api/tests.py
+++ b/backend/apps/api/tests.py
@@ -140,6 +140,14 @@ class PlayerInfoApiTests(TestCase):
         mock_client.fetch_player_info.return_value = {
             'currentTeam': {'id': 111, 'name': 'Team A'},
             'primaryPosition': {'name': 'Pitcher'},
+            'birthDate': '1990-01-01',
+            'birthCity': 'Some City',
+            'birthStateProvince': 'CA',
+            'birthCountry': 'USA',
+            'height': "6'2\"",
+            'weight': 200,
+            'batSide': {'description': 'Right'},
+            'pitchHand': {'description': 'Left'},
         }
 
         PlayerIdInfo.objects.create(
@@ -157,6 +165,12 @@ class PlayerInfoApiTests(TestCase):
         self.assertEqual(data['team_id'], 111)
         self.assertEqual(data['team_name'], 'Team A')
         self.assertEqual(data['position'], 'Pitcher')
+        self.assertEqual(data['birth_date'], '1990-01-01')
+        self.assertEqual(data['birth_place'], 'Some City, CA, USA')
+        self.assertEqual(data['height'], "6'2\"")
+        self.assertEqual(data['weight'], 200)
+        self.assertEqual(data['bat_side'], 'Right')
+        self.assertEqual(data['throw_side'], 'Left')
         mock_client.fetch_player_info.assert_called_once_with(123)
 
 

--- a/backend/apps/api/views.py
+++ b/backend/apps/api/views.py
@@ -266,11 +266,29 @@ def player_info(request, player_id: int):
         info = client.fetch_player_info(int(key_mlbam))
         team = info.get("currentTeam", {}) or {}
         pos = info.get("primaryPosition", {}) or {}
+        bat = info.get("batSide", {}) or {}
+        throw = info.get("pitchHand", {}) or {}
+        birth_city = info.get("birthCity")
+        birth_state = info.get("birthStateProvince")
+        birth_country = info.get("birthCountry")
+        birth_place_parts = [
+            part
+            for part in [birth_city, birth_state, birth_country]
+            if part
+        ]
+        birth_place = ", ".join(birth_place_parts) if birth_place_parts else None
+
         data = {
             "team_id": team.get("id"),
             "team_name": team.get("name"),
             "position": pos.get("name"),
-            "name": info.get("fullName")
+            "name": info.get("fullName"),
+            "birth_date": info.get("birthDate"),
+            "birth_place": birth_place,
+            "height": info.get("height"),
+            "weight": info.get("weight"),
+            "bat_side": bat.get("description"),
+            "throw_side": throw.get("description"),
         }
         return JsonResponse(data)
     except Exception as exc:  # pragma: no cover - defensive

--- a/frontend/src/views/PlayerView.vue
+++ b/frontend/src/views/PlayerView.vue
@@ -25,7 +25,30 @@
 
       <TabView>
         <TabPanel header="Overview">
-          <p>Overview content coming soon.</p>
+          <section
+            v-if="hasBio"
+            class="player-details biography"
+          >
+            <h2>Biography</h2>
+            <ul class="bio-list">
+              <li v-if="birthDate">
+                <strong>Birth Date:</strong> {{ formattedBirthDate }}
+              </li>
+              <li v-if="birthPlace">
+                <strong>Birthplace:</strong> {{ birthPlace }}
+              </li>
+              <li v-if="height">
+                <strong>Height:</strong> {{ height }}
+              </li>
+              <li v-if="weight">
+                <strong>Weight:</strong> {{ weight }} lbs
+              </li>
+              <li v-if="batSide || throwSide">
+                <strong>B/T:</strong>
+                {{ batSide || '?' }} / {{ throwSide || '?' }}
+              </li>
+            </ul>
+          </section>
         </TabPanel>
         <TabPanel header="Stats">
           <PlayerStats :id="id" />
@@ -54,6 +77,12 @@ const name = ref('');
 const teamName = ref('');
 const position = ref('');
 const teamLogoSrc = ref('');
+const birthDate = ref('');
+const birthPlace = ref('');
+const height = ref('');
+const weight = ref('');
+const batSide = ref('');
+const throwSide = ref('');
 
 const teamColorStyle = computed(() => {
   const colors = teamColors[teamName.value] || [];
@@ -64,6 +93,28 @@ const teamColorStyle = computed(() => {
   };
 });
 
+const formattedBirthDate = computed(() => {
+  if (!birthDate.value) return '';
+  try {
+    return new Date(birthDate.value).toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric'
+    });
+  } catch {
+    return birthDate.value;
+  }
+});
+
+const hasBio = computed(() =>
+  birthDate.value ||
+  birthPlace.value ||
+  height.value ||
+  weight.value ||
+  batSide.value ||
+  throwSide.value
+);
+
 onMounted(async () => {
   try {
     const resp = await fetch(`/api/players/${id}/`);
@@ -72,6 +123,12 @@ onMounted(async () => {
       name.value = data.name || '';
       teamName.value = data.team_name || '';
       position.value = data.position || '';
+      birthDate.value = data.birth_date || '';
+      birthPlace.value = data.birth_place || '';
+      height.value = data.height || '';
+      weight.value = data.weight || '';
+      batSide.value = data.bat_side || '';
+      throwSide.value = data.throw_side || '';
       if (data.team_id) {
         try {
           const logoResp = await fetch(`/api/teams/${data.team_id}/logo/`);
@@ -159,6 +216,24 @@ onMounted(async () => {
 
 .player-id {
   margin: 0;
+}
+
+.biography {
+  text-align: left;
+}
+
+.bio-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.bio-list li {
+  margin: 0.25rem 0;
+}
+
+.bio-list strong {
+  font-weight: 600;
 }
 </style>
 


### PR DESCRIPTION
## Summary
- extend `player_info` endpoint with birth details, height, weight, and handedness
- display a formatted Biography section on the player page

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed)*
- `npm test` *(fails: No test files found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7295b97c83268999cc736da9b9e3