### PR TITLE
Use career stats endpoint for PlayerView

### DIFF
--- a/backend/apps/api/tests.py
+++ b/backend/apps/api/tests.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import patch, call
 from django.test import TestCase, Client
 
 from apps.api.models import PlayerIdInfo, TeamIdInfo, Venue
@@ -178,11 +178,9 @@ class PlayerStatsApiTests(TestCase):
     @patch('apps.api.views.UnifiedDataClient')
     def test_player_stats_endpoint(self, mock_client_cls):
         mock_client = mock_client_cls.return_value
-        mock_client.fetch_player_stats_by_season.side_effect = [
-            {'season': 'batting-season'},
-            {'season': 'pitching-season'},
-            {'season': 'batting-career'},
-            {'season': 'pitching-career'},
+        mock_client.fetch_player_stats_career.side_effect = [
+            {'stats': ['bat']},
+            {'stats': ['pitch']},
         ]
 
         PlayerIdInfo.objects.create(
@@ -197,11 +195,12 @@ class PlayerStatsApiTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         data = response.json()
-        self.assertIn('season', data)
-        self.assertIn('career', data)
-        self.assertEqual(data['season']['batting']['season'], 'batting-season')
-        self.assertEqual(data['career']['pitching']['season'], 'pitching-career')
-        self.assertEqual(mock_client.fetch_player_stats_by_season.call_count, 4)
+        self.assertEqual(data['batting']['stats'], ['bat'])
+        self.assertEqual(data['pitching']['stats'], ['pitch'])
+        mock_client.fetch_player_stats_career.assert_has_calls([
+            call(123, group='batting'),
+            call(123, group='pitching'),
+        ])
 
 
 class PlayerSearchApiTests(TestCase):

--- a/backend/apps/api/views.py
+++ b/backend/apps/api/views.py
@@ -297,13 +297,11 @@ def player_info(request, player_id: int):
 
 @require_GET
 def player_stats(request, player_id: int):
-    """Return season and career statistics for a player.
+    """Return career statistics for a player.
 
     ``player_id`` may be either the internal ``PlayerIdInfo`` primary key or a
-    raw MLBAM player id.  The optional ``season`` query parameter selects the
-    season to fetch (defaults to the current year).  The response contains both
-    batting and pitching statistics for the given season along with career
-    totals when available.
+    raw MLBAM player id. The response includes career batting and pitching
+    statistics as returned by ``UnifiedDataClient.fetch_player_stats_career``.
     """
 
     if UnifiedDataClient is None:
@@ -330,37 +328,17 @@ def player_stats(request, player_id: int):
     if key_mlbam.endswith('.0'):
         key_mlbam = key_mlbam[:-2]
 
-    season_str = request.GET.get('season')
-    if season_str is None:
-        season_str = str(datetime.now().year)
-    try:
-        season = int(season_str)
-    except ValueError:
-        return JsonResponse({'error': 'Invalid season'}, status=400)
-
     try:
         client = UnifiedDataClient()
-        batting_season = client.fetch_player_stats_by_season(
-            int(key_mlbam), season, group='batting'
+        batting_career = client.fetch_player_stats_career(
+            int(key_mlbam), group='batting'
         )
-        pitching_season = client.fetch_player_stats_by_season(
-            int(key_mlbam), season, group='pitching'
-        )
-        batting_career = client.fetch_player_stats_by_season(
-            int(key_mlbam), 0, group='batting'
-        )
-        pitching_career = client.fetch_player_stats_by_season(
-            int(key_mlbam), 0, group='pitching'
+        pitching_career = client.fetch_player_stats_career(
+            int(key_mlbam), group='pitching'
         )
         data = {
-            'season': {
-                'batting': batting_season,
-                'pitching': pitching_season,
-            },
-            'career': {
-                'batting': batting_career,
-                'pitching': pitching_career,
-            },
+            'batting': batting_career,
+            'pitching': pitching_career,
         }
         return JsonResponse(data)
     except Exception as exc:  # pragma: no cover - defensive

--- a/frontend/src/components/PlayerStats.vue
+++ b/frontend/src/components/PlayerStats.vue
@@ -58,34 +58,20 @@ onMounted(async () => {
 const hittingFields = ['avg', 'homeRuns', 'rbi'];
 const pitchingFields = ['era', 'strikeOuts', 'wins', 'losses'];
 
-function buildRows(seasonStats, careerStats, fields) {
-  const rows = [];
-  if (seasonStats) {
-    for (const teamId of seasonStats.team_ids || []) {
-      const team = seasonStats.teams[teamId];
-      const row = { label: team.teamName };
-      fields.forEach(f => { row[f] = team.stats?.[f]; });
-      rows.push(row);
-    }
-    if (seasonStats.season && Object.keys(seasonStats.season).length) {
-      const totalRow = { label: 'Total' };
-      fields.forEach(f => { totalRow[f] = seasonStats.season[f]; });
-      rows.push(totalRow);
-    }
-  }
-  if (careerStats && careerStats.season && Object.keys(careerStats.season).length) {
-    const careerRow = { label: 'Career' };
-    fields.forEach(f => { careerRow[f] = careerStats.season[f]; });
-    rows.push(careerRow);
-  }
-  return rows;
+function buildRows(statData, fields) {
+  const splits = statData?.stats?.[0]?.splits || [];
+  return splits.map(split => {
+    const row = { label: split.season };
+    fields.forEach(f => { row[f] = split.stat?.[f]; });
+    return row;
+  });
 }
 
 const hittingRows = computed(() =>
-  buildRows(stats.value?.season?.batting, stats.value?.career?.batting, hittingFields)
+  buildRows(stats.value?.batting, hittingFields)
 );
 const pitchingRows = computed(() =>
-  buildRows(stats.value?.season?.pitching, stats.value?.career?.pitching, pitchingFields)
+  buildRows(stats.value?.pitching, pitchingFields)
 );
 </script>
 


### PR DESCRIPTION
## Summary
- Replace seasonal stats endpoint with career data from `fetch_player_stats_career`
- Render PlayerStats table from season splits of career data
- Update tests for career stats retrieval

## Testing
- `python manage.py test` (fails: connection refused)
- `npm test` (fails: No test files found)

------
https://chatgpt.com/codex/tasks/task_e_68aba289e5488326bf971ba60086893e