### PR TITLE
Use MLBAM id for player career stats

### DIFF
--- a/frontend/src/components/SearchAutocomplete.vue
+++ b/frontend/src/components/SearchAutocomplete.vue
@@ -35,6 +35,10 @@ const props = defineProps({
   routeName: {
     type: String,
     required: true
+  },
+  idField: {
+    type: String,
+    default: 'id'
   }
 });
 
@@ -62,9 +66,10 @@ async function search(event) {
 
 function onSelect(event) {
   const item = event.value;
+  const routeId = item[props.idField];
   router.push({
     name: props.routeName,
-    params: { id: item.id },
+    params: { id: routeId },
     query: { name: item[props.optionLabel] }
   });
 }

--- a/frontend/src/views/PlayersView.vue
+++ b/frontend/src/views/PlayersView.vue
@@ -7,6 +7,7 @@
         optionLabel="name_full"
         searchEndpoint="/api/players/"
         routeName="Player"
+        idField="key_mlbam"
       />
     </div>
   </section>


### PR DESCRIPTION
## Summary
- allow search autocomplete to specify which field to use for routing ids
- send MLBAM id from player search so PlayerView uses it for stats

## Testing
- `npm test` *(fails: No test files found)*
- `pytest` *(passes: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68aba447f960832692193fda93f07d91