### PR TITLE
Fix PlayerStats schema for batters

### DIFF
--- a/frontend/src/components/PlayerStats.vue
+++ b/frontend/src/components/PlayerStats.vue
@@ -59,7 +59,7 @@ const hittingFields = ['avg', 'homeRuns', 'rbi'];
 const pitchingFields = ['era', 'strikeOuts', 'wins', 'losses'];
 
 function buildRows(statData, fields) {
-  const splits = statData?.stats?.[0]?.splits || [];
+  const splits = statData?.splits || [];
   return splits.map(split => {
     const row = { label: split.season };
     fields.forEach(f => { row[f] = split.stat?.[f]; });
@@ -67,11 +67,17 @@ function buildRows(statData, fields) {
   });
 }
 
+function findGroup(name) {
+  return stats.value?.stats?.find(
+    s => s.group?.displayName?.toLowerCase() === name
+  );
+}
+
 const hittingRows = computed(() =>
-  buildRows(stats.value?.batting, hittingFields)
+  buildRows(findGroup('hitting'), hittingFields)
 );
 const pitchingRows = computed(() =>
-  buildRows(stats.value?.pitching, pitchingFields)
+  buildRows(findGroup('pitching'), pitchingFields)
 );
 </script>
 


### PR DESCRIPTION
## Summary
- Adjust PlayerStats component to parse stats grouped by `hitting` and `pitching`
- Build table rows from group `splits` so non-pitchers display correctly

## Testing
- `npm test` *(fails: No test files found)*
- `python manage.py test` *(fails: connection to PostgreSQL at "localhost" refused)*

------
https://chatgpt.com/codex/tasks/task_e_68abacb0889c8326b33364b8c8df87d6