### PR TITLE
feat: add quick player lists to PlayersView

### DIFF
--- a/frontend/src/components/PlayerQuickList.vue
+++ b/frontend/src/components/PlayerQuickList.vue
@@ -1,0 +1,51 @@
+<template>
+  <div class="player-list">
+    <h2>{{ title }}</h2>
+    <ul>
+      <li v-for="player in players" :key="player.id">
+        <RouterLink
+          :to="{ name: 'Player', params: { id: player.id }, query: { name: player.name } }"
+        >
+          {{ player.name }}
+        </RouterLink>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup>
+import { RouterLink } from 'vue-router';
+
+const props = defineProps({
+  title: {
+    type: String,
+    required: true
+  },
+  players: {
+    type: Array,
+    required: true
+  }
+});
+</script>
+
+<style scoped>
+.player-list {
+  margin-bottom: 2rem;
+}
+.player-list h2 {
+  font-size: 1.25rem;
+  margin-bottom: 0.5rem;
+}
+.player-list ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.player-list li {
+  margin-bottom: 0.25rem;
+}
+.player-list a {
+  color: var(--color-accent);
+}
+</style>
+

--- a/frontend/src/views/PlayersView.vue
+++ b/frontend/src/views/PlayersView.vue
@@ -1,20 +1,65 @@
 <template>
   <section class="search-page players-view">
-    <div class="search-container">
-      <h1>Players</h1>
-      <SearchAutocomplete
-        placeholder="Search for a player"
-        optionLabel="name_full"
-        searchEndpoint="/api/players/"
-        routeName="Player"
-        idField="key_mlbam"
-      />
+    <div class="content">
+      <div class="search-container">
+        <h1>Players</h1>
+        <SearchAutocomplete
+          placeholder="Search for a player"
+          optionLabel="name_full"
+          searchEndpoint="/api/players/"
+          routeName="Player"
+          idField="key_mlbam"
+        />
+      </div>
+      <aside class="sidebar">
+        <PlayerQuickList title="Popular Players" :players="popularPlayers" />
+        <PlayerQuickList title="Popular Batters" :players="popularBatters" />
+        <PlayerQuickList title="Popular Pitchers" :players="popularPitchers" />
+      </aside>
     </div>
   </section>
 </template>
 
 <script setup>
 import SearchAutocomplete from '../components/SearchAutocomplete.vue';
+import PlayerQuickList from '../components/PlayerQuickList.vue';
+
+const popularPlayers = [
+  { id: '660271', name: 'Shohei Ohtani' },
+  { id: '545361', name: 'Mike Trout' },
+  { id: '592450', name: 'Aaron Judge' },
+  { id: '605141', name: 'Mookie Betts' },
+  { id: '514888', name: 'Jose Altuve' }
+];
+
+const popularBatters = [
+  { id: '518692', name: 'Freddie Freeman' },
+  { id: '665742', name: 'Juan Soto' },
+  { id: '547180', name: 'Bryce Harper' },
+  { id: '665489', name: 'Vladimir Guerrero Jr.' },
+  { id: '646240', name: 'Rafael Devers' }
+];
+
+const popularPitchers = [
+  { id: '594798', name: 'Jacob deGrom' },
+  { id: '453286', name: 'Max Scherzer' },
+  { id: '434378', name: 'Justin Verlander' },
+  { id: '543037', name: 'Gerrit Cole' },
+  { id: '477132', name: 'Clayton Kershaw' }
+];
 </script>
 
+<style scoped>
+.players-view {
+  align-items: flex-start;
+}
+.players-view .content {
+  display: flex;
+  align-items: flex-start;
+  gap: 2rem;
+}
+.sidebar {
+  text-align: left;
+}
+</style>
 


### PR DESCRIPTION
## Summary
- add PlayerQuickList component to display lists of players
- show popular players, batters, and pitchers on Players page

## Testing
- `npm test` (fails: No test files found)


------
https://chatgpt.com/codex/tasks/task_e_68abb214fe5c8326a4b0283730efaac8