### PR TITLE
feat: color player stats header with team colors

### DIFF
--- a/frontend/src/components/PlayerStats.vue
+++ b/frontend/src/components/PlayerStats.vue
@@ -152,7 +152,8 @@ const pitchingRows = computed(() =>
   text-align: center;
 }
 .stats-table th {
-  background: rgba(0,0,0,0.05);
+  background: var(--color-primary);
+  color: #fff;
 }
 </style>
 


### PR DESCRIPTION
## Summary
- style player stats table headers with team's primary color for quick visual association

## Testing
- `pytest -q`
- `npm test --silent` *(fails: No test files found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68abce4f2fc883269c34af4bec42d444