### PR TITLE
Load team data concurrently

### DIFF
--- a/frontend/src/views/TeamView.vue
+++ b/frontend/src/views/TeamView.vue
@@ -318,10 +318,13 @@ async function resolveTeamId(teamId) {
   } catch (e) {
     internalTeamId.value = teamId;
   }
-  await loadTeamDetails(internalTeamId.value);
-  await loadRecentSchedule(internalTeamId.value);
-  await loadRoster(internalTeamId.value);
-  await loadLeaders(internalTeamId.value);
+  const id = internalTeamId.value;
+  await Promise.all([
+    loadTeamDetails(id).catch(() => {}),
+    loadRecentSchedule(id).catch(() => {}),
+    loadRoster(id).catch(() => {}),
+    loadLeaders(id).catch(() => {}),
+  ]);
 }
 
 onMounted(() => {


### PR DESCRIPTION
## Summary
- Fetch team details, recent schedule, roster, and leaders in parallel
- Prevent individual fetch failures from halting other data requests

## Testing
- `npm test` *(fails: No test files found)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acd6fe7f74832693208fe1a6689282