### PR TITLE
feat: cache team data with revalidation

### DIFF
--- a/frontend/src/store/teams.js
+++ b/frontend/src/store/teams.js
@@ -2,6 +2,30 @@ import { defineStore } from 'pinia';
 
 export const useTeamsStore = defineStore('teams', {
   state: () => ({
-    teams: []
-  })
+    teams: [],
+    details: {},
+    rosters: {},
+    standings: {},
+    leaders: {}
+  }),
+  getters: {
+    getDetails: (state) => (id) => state.details[id],
+    getRoster: (state) => (id) => state.rosters[id],
+    getStandings: (state) => (id) => state.standings[id],
+    getLeaders: (state) => (id) => state.leaders[id]
+  },
+  actions: {
+    setDetails(id, data) {
+      this.details[id] = data;
+    },
+    setRoster(id, data) {
+      this.rosters[id] = data;
+    },
+    setStandings(id, data) {
+      this.standings[id] = data;
+    },
+    setLeaders(id, data) {
+      this.leaders[id] = data;
+    }
+  }
 });


### PR DESCRIPTION
## Summary
- expand team store with per-team caches for details, rosters, standings, and leaders
- check Pinia store before network requests in TeamView and revalidate in background
- expose getters and actions to retrieve and update cached team data

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68ace15ea2a88326a807a1126639bf46