### PR TITLE
Display league leaders on players page

### DIFF
--- a/backend/apps/api/tests.py
+++ b/backend/apps/api/tests.py
@@ -381,3 +381,50 @@ class TeamRosterApiTests(TestCase):
         client = Client()
         response = client.get('/api/teams/1/roster/')
         self.assertEqual(response.status_code, 404)
+
+
+class LeagueLeadersApiTests(TestCase):
+    @patch('apps.api.views.UnifiedDataClient')
+    def test_league_leaders_endpoint(self, mock_client_cls):
+        mock_client = mock_client_cls.return_value
+
+        import pandas as pd
+
+        bat_df = pd.DataFrame(
+            {
+                'xMLBAMID': [1, 2],
+                'Name': ['<b>Player A</b>', 'Player B'],
+                'PA': [100, 120],
+                'HR': [10, 20],
+                'AVG': [0.300, 0.350],
+                'RBI': [30, 40],
+                'SB': [5, 10],
+                'SLG': [0.500, 0.600],
+                'OPS': [0.800, 0.900],
+            }
+        )
+        pit_df = pd.DataFrame(
+            {
+                'xMLBAMID': [3, 4],
+                'Name': ['Pitcher C', 'Pitcher D'],
+                'Pos': ['P', 'P'],
+                'IP': [50, 60],
+                'ERA': [2.5, 3.5],
+                'SO': [100, 80],
+                'W': [8, 10],
+                'SV': [1, 5],
+            }
+        )
+
+        mock_client.fetch_batting_leaderboards.return_value = bat_df
+        mock_client.fetch_pitching_leaderboards.return_value = pit_df
+
+        client = Client()
+        response = client.get('/api/leaders/')
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn('HR', data['batting'])
+        self.assertEqual(data['batting']['HR'][0]['id'], '2')
+        self.assertIn('ERA', data['pitching'])
+        self.assertEqual(data['pitching']['ERA'][0]['id'], '3')

--- a/backend/apps/api/urls.py
+++ b/backend/apps/api/urls.py
@@ -17,5 +17,6 @@ urlpatterns = [
     path('teams/<int:mlbam_team_id>/record/', views.team_record, name='api-team-record'),
     path('teams/<int:team_id>/recent_schedule/', views.team_recent_schedule, name='api-team-recent-schedule'),
     path('teams/<int:team_id>/roster/', views.team_roster, name='api-team-roster'),
+    path('leaders/', views.league_leaders, name='api-league-leaders'),
     path('teams/<int:team_id>/leaders/', views.team_leaders, name='api-team-leaders'),
 ]

--- a/frontend/src/components/PlayerQuickList.vue
+++ b/frontend/src/components/PlayerQuickList.vue
@@ -8,6 +8,7 @@
         >
           {{ player.name }}
         </RouterLink>
+        <span v-if="player.value != null"> {{ formatValue(player.value) }}</span>
       </li>
     </ul>
   </div>
@@ -26,6 +27,17 @@ const props = defineProps({
     required: true
   }
 });
+
+const formatValue = (val) => {
+  const num = Number(val);
+  if (!isNaN(num)) {
+    if (num < 1) {
+      return num.toFixed(3).replace(/^0\./, '.');
+    }
+    return num.toString();
+  }
+  return val;
+};
 </script>
 
 <style scoped>

--- a/frontend/src/views/PlayersView.vue
+++ b/frontend/src/views/PlayersView.vue
@@ -12,9 +12,26 @@
         />
       </div>
       <aside class="sidebar">
-        <PlayerQuickList title="Popular Players" :players="popularPlayers" />
-        <PlayerQuickList title="Popular Batters" :players="popularBatters" />
-        <PlayerQuickList title="Popular Pitchers" :players="popularPitchers" />
+        <PlayerQuickList
+          v-if="leaders?.batting?.HR"
+          title="HR Leaders"
+          :players="leaders.batting.HR"
+        />
+        <PlayerQuickList
+          v-if="leaders?.batting?.AVG"
+          title="AVG Leaders"
+          :players="leaders.batting.AVG"
+        />
+        <PlayerQuickList
+          v-if="leaders?.pitching?.ERA"
+          title="ERA Leaders"
+          :players="leaders.pitching.ERA"
+        />
+        <PlayerQuickList
+          v-if="leaders?.pitching?.SO"
+          title="SO Leaders"
+          :players="leaders.pitching.SO"
+        />
       </aside>
     </div>
   </section>
@@ -23,30 +40,19 @@
 <script setup>
 import SearchAutocomplete from '../components/SearchAutocomplete.vue';
 import PlayerQuickList from '../components/PlayerQuickList.vue';
+import { onMounted, ref } from 'vue';
 
-const popularPlayers = [
-  { id: '660271', name: 'Shohei Ohtani' },
-  { id: '545361', name: 'Mike Trout' },
-  { id: '592450', name: 'Aaron Judge' },
-  { id: '605141', name: 'Mookie Betts' },
-  { id: '514888', name: 'Jose Altuve' }
-];
+const leaders = ref(null);
 
-const popularBatters = [
-  { id: '518692', name: 'Freddie Freeman' },
-  { id: '665742', name: 'Juan Soto' },
-  { id: '547180', name: 'Bryce Harper' },
-  { id: '665489', name: 'Vladimir Guerrero Jr.' },
-  { id: '646240', name: 'Rafael Devers' }
-];
-
-const popularPitchers = [
-  { id: '594798', name: 'Jacob deGrom' },
-  { id: '453286', name: 'Max Scherzer' },
-  { id: '434378', name: 'Justin Verlander' },
-  { id: '543037', name: 'Gerrit Cole' },
-  { id: '477132', name: 'Clayton Kershaw' }
-];
+onMounted(async () => {
+  try {
+    const res = await fetch('/api/leaders/');
+    leaders.value = await res.json();
+  } catch (e) {
+    console.error('Failed to fetch league leaders:', e);
+    leaders.value = null;
+  }
+});
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- add `/api/leaders/` endpoint to return league-wide batting and pitching leaders
- show league leaders on Players view instead of static lists
- display stat values in quick player lists
- add test for new league leaders API

## Testing
- `python manage.py test` *(fails: connection refused to PostgreSQL)*
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68ace1bd9e348326bcb7e7b6532ecd58