### PR TITLE
refactor: extract PlayerStats field constants to config

### DIFF
--- a/frontend/src/components/PlayerStats.vue
+++ b/frontend/src/components/PlayerStats.vue
@@ -73,6 +73,14 @@
 
 <script setup>
 import { ref, onMounted, computed } from 'vue';
+import {
+  standardHittingFields,
+  advancedHittingFields,
+  standardPitchingFields,
+  advancedPitchingFields,
+  fieldLabels
+} from '../config/playerStatsConfig.js';
+
 
 const { id } = defineProps({ id: String });
 
@@ -91,66 +99,7 @@ onMounted(async () => {
   }
 });
 
-const standardHittingFields = ['team','atBats', 'hits', 'doubles', 'triples', 'avg', 'runs','homeRuns', 'rbi', 
-                      'baseOnBalls', 'intentionalWalks', 'strikeOuts', 'stolenBases', 'caughtStealing',
-                      'obp', 'slg', 'ops'];
-const advancedHittingFields = ['team','plateAppearances', 'totalBases', 'extraBaseHits', 'hitByPitch', 'sacBunts', 
-                               'sacFlies','babip', 'gidp','gidpOpp', 'numberOfPitches', 'pitchesPerPlateAppearance', 
-                               'reachedOnError', 'leftOnBase', 'walkOffs'];
-const standardPitchingFields = ['team','inningsPitched','era', 'strikeOuts', 'wins', 'losses'];
-const advancedPitchingFields = ['team','qualityStarts','gamesFinished', 'doubles', 'triples', 'gidp','gidpOpp',
-                                'wildPitches','balks','stolenBases','caughtStealing','pickoffs','strikePercentage',
-                                'pitchesPerInning','pitchesPerPlateAppearance'
-];
 
-const fieldLabels = {
-  atBats: 'AB',
-  hits: 'H',
-  doubles: '2B',
-  triples: '3B',
-  avg: 'AVG',
-  runs: 'R',
-  homeRuns: 'HR',
-  rbi: 'RBI',
-  inningsPitched: 'IP',
-  era: 'ERA',
-  strikeOuts: 'SO',
-  wins: 'W',
-  losses: 'L',
-  team: 'Team',
-  baseOnBalls: 'BB',
-  intentionalWalks: 'IBB',
-  strikeOuts: 'SO',
-  stolenBases: 'SB',
-  caughtStealing: 'CS',
-  obp: 'OBP',
-  slg: 'SLG',
-  ops: 'OPS',
-  totalBases: 'TB',
-  extraBaseHits: 'XBH',
-  plateAppearances: 'PA',
-  hitByPitch: 'HBP',
-  sacBunts: 'SAC B',
-  sacFlies: 'SAC F',
-  babip: 'BABIP',
-  gidp: 'GIDP',
-  gidpOpp: 'GIDPO',
-  numberOfPitches: 'NP',
-  pitchesPerPlateAppearance: 'P/PA',
-  reachedOnError: 'ROE',
-  leftOnBase: 'LOB',
-  walkOffs: 'WO',
-  qualityStarts: 'QS',
-  gamesFinished: 'GF',
-  doubles: '2B',
-  triples: '3B',
-  wildPitches: 'WP',
-  balks: 'BK',
-  pickoffs: 'PK',
-  strikePercentage: 'S%',
-  pitchesPerInning: 'P/IP',
-  pitchesPerPlateAppearance: 'P/PA'
-};
 
 async function fetchTeamAbbrevs(statGroups) {
   const ids = new Set();

--- a/frontend/src/config/playerStatsConfig.js
+++ b/frontend/src/config/playerStatsConfig.js
@@ -1,0 +1,58 @@
+export const standardHittingFields = ['team','atBats', 'hits', 'doubles', 'triples', 'avg', 'runs','homeRuns', 'rbi',
+  'baseOnBalls', 'intentionalWalks', 'strikeOuts', 'stolenBases', 'caughtStealing',
+  'obp', 'slg', 'ops'];
+
+export const advancedHittingFields = ['team','plateAppearances', 'totalBases', 'extraBaseHits', 'hitByPitch', 'sacBunts',
+  'sacFlies','babip', 'gidp','gidpOpp', 'numberOfPitches', 'pitchesPerPlateAppearance',
+  'reachedOnError', 'leftOnBase', 'walkOffs'];
+
+export const standardPitchingFields = ['team','inningsPitched','era', 'strikeOuts', 'wins', 'losses'];
+
+export const advancedPitchingFields = ['team','qualityStarts','gamesFinished', 'doubles', 'triples', 'gidp','gidpOpp',
+  'wildPitches','balks','stolenBases','caughtStealing','pickoffs','strikePercentage',
+  'pitchesPerInning','pitchesPerPlateAppearance'];
+
+export const fieldLabels = {
+  atBats: 'AB',
+  hits: 'H',
+  doubles: '2B',
+  triples: '3B',
+  avg: 'AVG',
+  runs: 'R',
+  homeRuns: 'HR',
+  rbi: 'RBI',
+  inningsPitched: 'IP',
+  era: 'ERA',
+  strikeOuts: 'SO',
+  wins: 'W',
+  losses: 'L',
+  team: 'Team',
+  baseOnBalls: 'BB',
+  intentionalWalks: 'IBB',
+  stolenBases: 'SB',
+  caughtStealing: 'CS',
+  obp: 'OBP',
+  slg: 'SLG',
+  ops: 'OPS',
+  totalBases: 'TB',
+  extraBaseHits: 'XBH',
+  plateAppearances: 'PA',
+  hitByPitch: 'HBP',
+  sacBunts: 'SAC B',
+  sacFlies: 'SAC F',
+  babip: 'BABIP',
+  gidp: 'GIDP',
+  gidpOpp: 'GIDPO',
+  numberOfPitches: 'NP',
+  pitchesPerPlateAppearance: 'P/PA',
+  reachedOnError: 'ROE',
+  leftOnBase: 'LOB',
+  walkOffs: 'WO',
+  qualityStarts: 'QS',
+  gamesFinished: 'GF',
+  wildPitches: 'WP',
+  balks: 'BK',
+  pickoffs: 'PK',
+  strikePercentage: 'S%',
+  pitchesPerInning: 'P/IP',
+};


### PR DESCRIPTION
## Summary
- centralize PlayerStats field arrays and labels in a dedicated config file
- update PlayerStats component to import field configuration

## Testing
- `npm test` *(fails: No test files found)*
- `pytest` *(fails: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68ace25ad4988326b4b80636fe0ddf6e