### PR TITLE
feat: add API explorer page

### DIFF
--- a/backend/apps/api/urls.py
+++ b/backend/apps/api/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
+    path('endpoints/', views.list_api_endpoints, name='api-endpoints'),
     path('schedule/', views.schedule, name='api-schedule'),
     path('games/<int:game_pk>/', views.game_data, name='api-game-data'),
     path('games/<int:game_pk>/prediction/', views.predict_game, name='api-game-prediction'),

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -8,6 +8,7 @@ import PlayersView from '../views/PlayersView.vue';
 import PlayerView from '../views/PlayerView.vue';
 import GameView from '../views/GameView.vue';
 import NewGameView from '../views/NewGameView.vue';
+import ApiExplorerView from '../views/ApiExplorerView.vue';
 
 const routes = [
   {
@@ -58,6 +59,11 @@ const routes = [
     name: 'Player',
     component: PlayerView,
     props: route => ({ id: route.params.id, name: route.query.name })
+  },
+  {
+    path: '/developer',
+    name: 'ApiExplorer',
+    component: ApiExplorerView
   },
   {
     path: '/game/:game_pk',

--- a/frontend/src/views/ApiExplorerView.vue
+++ b/frontend/src/views/ApiExplorerView.vue
@@ -1,0 +1,88 @@
+<template>
+  <section class="api-explorer">
+    <h2>API Explorer</h2>
+    <div v-if="endpoints.length">
+      <label for="endpoint-select">Endpoint:</label>
+      <select id="endpoint-select" v-model="selected">
+        <option :value="null" disabled>Select an endpoint</option>
+        <option v-for="ep in endpoints" :key="ep.template" :value="ep">
+          {{ ep.path }}
+        </option>
+      </select>
+      <div v-if="selected">
+        <div v-for="param in selected.params" :key="param" class="param-input">
+          <label :for="param">{{ param }}</label>
+          <input :id="param" v-model="params[param]" />
+        </div>
+        <div class="query-input">
+          <label for="query">Query</label>
+          <input id="query" placeholder="e.g., date=2024-04-01" v-model="query" />
+        </div>
+        <button @click="callEndpoint">Fetch</button>
+      </div>
+      <pre v-if="result">{{ result }}</pre>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { ref, onMounted, watch } from 'vue';
+
+const endpoints = ref([]);
+const selected = ref(null);
+const params = ref({});
+const query = ref('');
+const result = ref('');
+
+onMounted(async () => {
+  try {
+    const res = await fetch('/api/endpoints/');
+    if (res.ok) {
+      const data = await res.json();
+      endpoints.value = data.endpoints || [];
+    }
+  } catch (e) {
+    // ignore
+  }
+});
+
+watch(selected, () => {
+  params.value = {};
+  query.value = '';
+  result.value = '';
+});
+
+async function callEndpoint() {
+  if (!selected.value) return;
+  let url = selected.value.template;
+  for (const [key, val] of Object.entries(params.value)) {
+    url = url.replace(new RegExp(`<[^:>]+:${key}>`), encodeURIComponent(val));
+  }
+  if (query.value) {
+    url += `?${query.value}`;
+  }
+  const resp = await fetch(url);
+  try {
+    const data = await resp.json();
+    result.value = JSON.stringify(data, null, 2);
+  } catch (e) {
+    result.value = 'Invalid JSON response';
+  }
+}
+</script>
+
+<style scoped>
+.api-explorer {
+  padding: 2rem;
+}
+.param-input,
+.query-input {
+  margin-top: 1rem;
+}
+pre {
+  margin-top: 1rem;
+  background: #f5f5f5;
+  padding: 1rem;
+  overflow: auto;
+}
+</style>

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -79,6 +79,12 @@ const features = [
     icon: 'pi-user',
     description: 'Dive into detailed player analytics.',
     link: '/players'
+  },
+  {
+    title: 'API Explorer',
+    icon: 'pi-code',
+    description: 'Interact with backend API endpoints.',
+    link: '/developer'
   }
 ];
 


### PR DESCRIPTION
## Summary
- expose API endpoint list at `/api/endpoints/`
- add developer API Explorer page to browse endpoints and view results
- link API Explorer from router and home page

## Testing
- `pytest`
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4b762d9483269ae051628bbf3c26