### PR TITLE
Display API Explorer query field only when needed

### DIFF
--- a/backend/apps/api/views.py
+++ b/backend/apps/api/views.py
@@ -33,6 +33,14 @@ except Exception as exc:  # pragma: no cover - handles missing dependency
 def list_api_endpoints(request):
     from . import urls as api_urls
     endpoints = []
+    # Map endpoint names to query parameters they accept.
+    query_params = {
+        'api-schedule': ['date'],
+        'api-player-search': ['q'],
+        'api-team-search': ['q'],
+        'api-team-record': ['season'],
+    }
+
     for pattern in api_urls.urlpatterns:
         if isinstance(pattern, URLPattern):
             route = pattern.pattern._route
@@ -44,6 +52,7 @@ def list_api_endpoints(request):
                     'path': f'/api/{display}',
                     'template': f'/api/{route}',
                     'params': params,
+                    'query_params': query_params.get(pattern.name, []),
                 }
             )
     return JsonResponse({'endpoints': endpoints})

--- a/frontend/src/views/ApiExplorerView.vue
+++ b/frontend/src/views/ApiExplorerView.vue
@@ -16,9 +16,9 @@
               <label :for="param">{{ param }}</label>
               <input :id="param" v-model="params[param]" />
             </div>
-            <div class="query-input">
+            <div v-if="selected.query_params && selected.query_params.length" class="query-input">
               <label for="query">Query</label>
-              <input id="query" placeholder="e.g., date=2024-04-01" v-model="query" />
+              <input id="query" :placeholder="queryPlaceholder" v-model="query" />
             </div>
             <button @click="callEndpoint">Fetch</button>
           </div>
@@ -45,7 +45,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted, watch } from 'vue';
+import { ref, onMounted, watch, computed } from 'vue';
 
 const endpoints = ref([]);
 const selected = ref(null);
@@ -53,6 +53,13 @@ const params = ref({});
 const query = ref('');
 const result = ref(null);
 const resultType = ref('');
+
+const queryPlaceholder = computed(() => {
+  if (!selected.value || !selected.value.query_params || !selected.value.query_params.length) {
+    return 'e.g., param=value';
+  }
+  return `e.g., ${selected.value.query_params.map((p) => `${p}=value`).join('&')}`;
+});
 
 const samplePlayers = [
   { id: 669373, name: 'Tarik Skubal' },


### PR DESCRIPTION
## Summary
- Annotate API endpoint metadata with supported query params
- Conditionally render query input in API Explorer based on those params

## Testing
- `npm test` *(fails: No test files found)*
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68ad527561e88326932963bf6af1bdd4