### PR TITLE
Add UnifiedDataClient method explorer

### DIFF
--- a/backend/apps/api/urls.py
+++ b/backend/apps/api/urls.py
@@ -3,6 +3,8 @@ from . import views
 
 urlpatterns = [
     path('endpoints/', views.list_api_endpoints, name='api-endpoints'),
+    path('unified/methods/', views.unified_client_methods, name='api-unified-methods'),
+    path('unified/<str:method_name>/', views.unified_client_call, name='api-unified-call'),
     path('schedule/', views.schedule, name='api-schedule'),
     path('games/<int:game_pk>/', views.game_data, name='api-game-data'),
     path('games/<int:game_pk>/prediction/', views.predict_game, name='api-game-prediction'),


### PR DESCRIPTION
## Summary
- expose UnifiedDataClient methods and invocation endpoints on the backend
- extend API Explorer to choose UnifiedDataClient methods and supply parameters

## Testing
- `pytest backend/apps`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68add9ef23b883268c15a4709e006009