### PR TITLE
style: adjust standings table typography

### DIFF
--- a/frontend/src/views/StandingsView.vue
+++ b/frontend/src/views/StandingsView.vue
@@ -262,15 +262,19 @@ onMounted(() => {
   color: var(--color-accent);
 }
 
+
 .standings-table .p-datatable-header,
 .standings-table .p-datatable-thead > tr > th {
   background-color: var(--color-accent);
   color: var(--color-primary);
 }
 
-.standings-table td a {
+.standings-table td {
   font-size: 13px;
   font-family: proxima-nova, "open Sans", Helvetica, Arial, sans-serif;
+}
+
+.standings-table td a {
   font-weight: bold;
 }
 


### PR DESCRIPTION
## Summary
- ensure standings table rows use consistent typography

## Testing
- `npm --prefix frontend test` (fails: No test files found)

------
https://chatgpt.com/codex/tasks/task_e_68ae16523cf083269f4f8a103618cd71