### PR TITLE
Show team streak in standard standings

### DIFF
--- a/frontend/src/views/StandingsView.vue
+++ b/frontend/src/views/StandingsView.vue
@@ -50,6 +50,11 @@
                 <Column field="winningPercentage" header="PCT"></Column>
                 <Column field="divisionGamesBack" header="GB"></Column>
                 <Column field="wildCardGamesBack" header="WCGB"></Column>
+                <Column header="STRK">
+                  <template #body="{ data }">
+                    {{ data.streak?.streakCode }}
+                  </template>
+                </Column>
               </DataTable>
             </div>
           </TabPanel>


### PR DESCRIPTION
## Summary
- Display each team's current streak in the standard standings view

## Testing
- `npm test` (no test files found)


------
https://chatgpt.com/codex/tasks/task_e_68ae1747614c832693af769ae5757ce9