### PR TITLE
Add L10 column to standings view

### DIFF
--- a/frontend/src/views/StandingsView.vue
+++ b/frontend/src/views/StandingsView.vue
@@ -50,6 +50,11 @@
                 <Column field="winningPercentage" header="PCT"></Column>
                 <Column field="divisionGamesBack" header="GB"></Column>
                 <Column field="wildCardGamesBack" header="WCGB"></Column>
+                <Column header="L10">
+                  <template #body="{ data }">
+                    {{ lastTenRecord(data) }}
+                  </template>
+                </Column>
                 <Column header="STRK">
                   <template #body="{ data }">
                     {{ data.streak?.streakCode }}
@@ -196,6 +201,13 @@ function divisionRecord(teamRecord, divisionId) {
     divisionId === 201 || divisionId === 204 ? 1 : 2;
   const r = teamRecord.records.divisionRecords[idx] || {};
   return `${r.wins}-${r.losses}`;
+}
+
+function lastTenRecord(teamRecord) {
+  const split = teamRecord.records?.splitRecords?.find(
+    (r) => r.type === 'lastTen'
+  );
+  return split ? `${split.wins}-${split.losses}` : '';
 }
 
 function formatRunDifferential(diff) {


### PR DESCRIPTION
## Summary
- show last ten record for each team in Standard standings view

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ae18b67f6c8326b9b16895c40460d7