### PR TITLE
Left align team names on standings view

### DIFF
--- a/frontend/src/views/StandingsView.vue
+++ b/frontend/src/views/StandingsView.vue
@@ -329,19 +329,27 @@ onMounted(() => {
   text-align: center;
 }
 
+:deep(.p-datatable-column-header-content) {
+  text-align: center;
+  display: inline;
+}
+
 :deep(.standings-table .p-datatable-tbody > tr > td) {
   font-size: 13px;
   font-family: proxima-nova, "open Sans", Helvetica, Arial, sans-serif;
   text-align: center;
 }
 
-:deep(.standings-table .p-datatable-tbody > tr > td a) {
-  font-weight: bold;
+:deep(
+    .standings-table .p-datatable-thead > tr > th:first-child,
+    .standings-table .p-datatable-thead > tr > th:first-child .p-datatable-column-header-content,
+    .standings-table .p-datatable-tbody > tr > td:first-child
+  ) {
+  text-align: left;
 }
 
-:deep(.p-datatable-column-header-content) {
-  text-align: center;
-  display: inline;
+:deep(.standings-table .p-datatable-tbody > tr > td a) {
+  font-weight: bold;
 }
 
 </style>


### PR DESCRIPTION
## Summary
- Left-align the team column in StandingsView for improved readability

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6164a6b08326b76d8b7b333afef5