### PR TITLE
Ensure ERA leaders show two decimal places

### DIFF
--- a/frontend/src/components/PlayerQuickList.vue
+++ b/frontend/src/components/PlayerQuickList.vue
@@ -25,12 +25,19 @@ const props = defineProps({
   players: {
     type: Array,
     required: true
-  }
+  },
+  decimalPlaces: {
+    type: Number,
+    default: null,
+  },
 });
 
 const formatValue = (val) => {
   const num = Number(val);
   if (!isNaN(num)) {
+    if (props.decimalPlaces !== null) {
+      return num.toFixed(props.decimalPlaces);
+    }
     if (num < 1) {
       return num.toFixed(3).replace(/^0\./, '.');
     }

--- a/frontend/src/views/PlayersView.vue
+++ b/frontend/src/views/PlayersView.vue
@@ -31,6 +31,7 @@
           v-if="leaders?.pitching?.ERA"
           title="ERA Leaders"
           :players="leaders.pitching.ERA"
+          :decimal-places="2"
         />
         <PlayerQuickList
           v-if="leaders?.pitching?.SO"


### PR DESCRIPTION
## Summary
- allow `PlayerQuickList` to accept a `decimalPlaces` prop for custom value formatting
- format ERA leader values with two decimal places in `PlayersView`

## Testing
- `npm test` *(fails: No test files found)*
- `python manage.py test` *(fails: connection to PostgreSQL refused)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6e9178548326b520406ba0fc9bd5