### PR TITLE
Display WHIP leaders with two decimal places

### DIFF
--- a/frontend/src/views/PlayersView.vue
+++ b/frontend/src/views/PlayersView.vue
@@ -42,6 +42,7 @@
           v-if="leaders?.pitching?.WHIP"
           title="WHIP Leaders"
           :players="leaders.pitching.WHIP"
+          :decimal-places="2"
         />
       </aside>
     </div>


### PR DESCRIPTION
## Summary
- Ensure WHIP leaders show values with a leading zero and two decimals on PlayersView

## Testing
- `npm test` (fails: No test files found)
- `pytest` (passes: no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_68ae70504d288326a5d6a09542fda1e4