### PR TITLE
Show teams grouped by league

### DIFF
--- a/frontend/src/data/mlbTeams.json
+++ b/frontend/src/data/mlbTeams.json
@@ -1,0 +1,36 @@
+{
+  "AL": [
+    { "name": "Baltimore Orioles", "mlbam_team_id": 110 },
+    { "name": "Boston Red Sox", "mlbam_team_id": 111 },
+    { "name": "New York Yankees", "mlbam_team_id": 147 },
+    { "name": "Tampa Bay Rays", "mlbam_team_id": 139 },
+    { "name": "Toronto Blue Jays", "mlbam_team_id": 141 },
+    { "name": "Chicago White Sox", "mlbam_team_id": 145 },
+    { "name": "Cleveland Guardians", "mlbam_team_id": 114 },
+    { "name": "Detroit Tigers", "mlbam_team_id": 116 },
+    { "name": "Kansas City Royals", "mlbam_team_id": 118 },
+    { "name": "Minnesota Twins", "mlbam_team_id": 142 },
+    { "name": "Houston Astros", "mlbam_team_id": 117 },
+    { "name": "Los Angeles Angels", "mlbam_team_id": 108 },
+    { "name": "Oakland Athletics", "mlbam_team_id": 133 },
+    { "name": "Seattle Mariners", "mlbam_team_id": 136 },
+    { "name": "Texas Rangers", "mlbam_team_id": 140 }
+  ],
+  "NL": [
+    { "name": "Atlanta Braves", "mlbam_team_id": 144 },
+    { "name": "Miami Marlins", "mlbam_team_id": 146 },
+    { "name": "New York Mets", "mlbam_team_id": 121 },
+    { "name": "Philadelphia Phillies", "mlbam_team_id": 143 },
+    { "name": "Washington Nationals", "mlbam_team_id": 120 },
+    { "name": "Chicago Cubs", "mlbam_team_id": 112 },
+    { "name": "Cincinnati Reds", "mlbam_team_id": 113 },
+    { "name": "Milwaukee Brewers", "mlbam_team_id": 158 },
+    { "name": "Pittsburgh Pirates", "mlbam_team_id": 134 },
+    { "name": "St. Louis Cardinals", "mlbam_team_id": 138 },
+    { "name": "Arizona Diamondbacks", "mlbam_team_id": 109 },
+    { "name": "Colorado Rockies", "mlbam_team_id": 115 },
+    { "name": "Los Angeles Dodgers", "mlbam_team_id": 119 },
+    { "name": "San Diego Padres", "mlbam_team_id": 135 },
+    { "name": "San Francisco Giants", "mlbam_team_id": 137 }
+  ]
+}

--- a/frontend/src/views/TeamsView.vue
+++ b/frontend/src/views/TeamsView.vue
@@ -1,19 +1,56 @@
 <template>
-  <section class="search-page teams-view">
-    <div class="search-container">
+  <section class="teams-view">
+    <div class="teams-container">
       <h1>Teams</h1>
-      <SearchAutocomplete
-        placeholder="Search for a team"
-        optionLabel="full_name"
-        searchEndpoint="/api/teams/"
-        routeName="Team"
-      />
+      <div class="team-columns">
+        <div class="team-column">
+          <h2>American League</h2>
+          <ul>
+            <li
+              v-for="team in teams.AL"
+              :key="team.mlbam_team_id"
+            >
+              <RouterLink
+                :to="{ name: 'Team', params: { mlbam_team_id: team.mlbam_team_id }, query: { name: team.name } }"
+              >
+                {{ team.name }}
+              </RouterLink>
+            </li>
+          </ul>
+        </div>
+        <div class="team-column">
+          <h2>National League</h2>
+          <ul>
+            <li
+              v-for="team in teams.NL"
+              :key="team.mlbam_team_id"
+            >
+              <RouterLink
+                :to="{ name: 'Team', params: { mlbam_team_id: team.mlbam_team_id }, query: { name: team.name } }"
+              >
+                {{ team.name }}
+              </RouterLink>
+            </li>
+          </ul>
+        </div>
+      </div>
     </div>
   </section>
 </template>
 
 <script setup>
-import SearchAutocomplete from '../components/SearchAutocomplete.vue';
+import teams from '../data/mlbTeams.json';
 </script>
+
+<style scoped>
+.team-columns {
+  display: flex;
+  gap: 2rem;
+}
+
+.team-column {
+  flex: 1;
+}
+</style>
 
 


### PR DESCRIPTION
## Summary
- replace team search with a full AL and NL team list
- add static MLB team data with league and IDs

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7291127c8326b3b82a600c5f3c91