### PR TITLE
style: enhance teams page layout

### DIFF
--- a/frontend/src/views/TeamsView.vue
+++ b/frontend/src/views/TeamsView.vue
@@ -43,13 +43,49 @@ import teams from '../data/mlbTeams.json';
 </script>
 
 <style scoped>
+.teams-view {
+  font-family: var(--font-base);
+  min-height: 100vh;
+  background: linear-gradient(135deg, var(--color-primary), var(--color-secondary));
+  color: #fff;
+  padding: 2rem 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.teams-container {
+  max-width: 1100px;
+  margin: 0 auto;
+  text-align: center;
+}
+
 .team-columns {
   display: flex;
   gap: 2rem;
+  justify-content: center;
+  margin-top: 2rem;
 }
 
 .team-column {
   flex: 1;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 0.5rem;
+  padding: 1rem;
+}
+
+.team-column h2 {
+  color: var(--color-accent);
+}
+
+.team-column ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.team-column li {
+  margin: 0.5rem 0;
 }
 </style>
 


### PR DESCRIPTION
## Summary
- Apply consistent site styling to the Teams page
- Add layout container and accent cards for AL/NL listings

## Testing
- `npm test > /tmp/unit.log 2>&1; tail -n 20 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68ae73f591a88326b564c7dc17169943