### PR TITLE
Add Developer link to navigation

### DIFF
--- a/backend/apps/web/templates/web/base.html
+++ b/backend/apps/web/templates/web/base.html
@@ -8,6 +8,7 @@
         .top-nav {
             background-color: #007bff;
             padding: 10px;
+            display: flex;
         }
         .top-nav a {
             color: white;
@@ -15,6 +16,9 @@
             text-decoration: none;
             padding: 5px 10px;
             border-radius: 4px;
+        }
+        .top-nav a.developer-link {
+            margin-left: auto;
         }
         .top-nav a:hover,
         .top-nav a.active {
@@ -29,11 +33,18 @@
 </head>
 <body>
     <nav class="top-nav">
-        <a href="{% url 'home' %}" class="{% if request.resolver_match.url_name == 'home' %}active{% endif %}">Home</a>
-        <a href="{% url 'schedule' %}" class="{% if request.resolver_match.url_name == 'schedule' %}active{% endif %}">Schedule</a>
-        <a href="{% url 'standings' %}" class="{% if request.resolver_match.url_name == 'standings' %}active{% endif %}">Standings</a>
-        <a href="{% url 'teams' %}" class="{% if request.resolver_match.url_name == 'teams' %}active{% endif %}">Teams</a>
-        <a href="{% url 'players' %}" class="{% if request.resolver_match.url_name == 'players' %}active{% endif %}">Players</a>
+        <a href="{% url 'home' %}"
+           class="{% if request.resolver_match.url_name == 'home' %}active{% endif %}">Home</a>
+        <a href="{% url 'schedule' %}"
+           class="{% if request.resolver_match.url_name == 'schedule' %}active{% endif %}">Schedule</a>
+        <a href="{% url 'standings' %}"
+           class="{% if request.resolver_match.url_name == 'standings' %}active{% endif %}">Standings</a>
+        <a href="{% url 'teams' %}"
+           class="{% if request.resolver_match.url_name == 'teams' %}active{% endif %}">Teams</a>
+        <a href="{% url 'players' %}"
+           class="{% if request.resolver_match.url_name == 'players' %}active{% endif %}">Players</a>
+        <a href="{% url 'developer' %}"
+           class="{% if request.resolver_match.url_name == 'developer' %}active{% endif %} developer-link">Developer</a>
     </nav>
     {% block content %}{% endblock %}
 </body>

--- a/backend/apps/web/templates/web/developer.html
+++ b/backend/apps/web/templates/web/developer.html
@@ -1,0 +1,13 @@
+{% extends "web/base.html" %}
+{% load static %}
+{% block title %}Developer{% endblock %}
+{% block content %}
+<h1 style="font-family: proxima-nova, 'open Sans', Helvetica, Arial, sans-serif;">Developer</h1>
+<div id="vue-app"></div>
+{% if DJANGO_USE_VITE_DEV %}
+    <script type="module" src="http://localhost:5173/@vite/client"></script>
+    <script type="module" src="http://localhost:5173/src/main.js"></script>
+{% else %}
+    <script src="{% static 'frontend/main.js' %}"></script>
+{% endif %}
+{% endblock %}

--- a/backend/apps/web/urls.py
+++ b/backend/apps/web/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     path('team/<int:mlbam_team_id>/', views.team, name='team'),
     path('player/<int:player_id>/', views.player, name='player'),
     path('players/', views.players, name='players'),
+    path('developer/', views.developer, name='developer'),
     path('game/<int:game_pk>/', views.game, name='game'),
     path('new-game/<int:game_pk>/', views.new_game, name='new_game')
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/backend/apps/web/views.py
+++ b/backend/apps/web/views.py
@@ -79,3 +79,7 @@ def game(request, game_pk: int):
 
 def new_game(request, game_pk: int = None):
     return render(request, 'web/new_game.html', {'game_pk': game_pk})
+
+
+def developer(request):
+    return render(request, 'web/developer.html')


### PR DESCRIPTION
## Summary
- add "Developer" link to top nav and align it to the right
- create backend route and view to serve the API Explorer page

## Testing
- `pytest`
- `cd frontend && npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7699c7288326b3d0fd32e329821f