### PR TITLE
refactor: centralize API fetch logic in frontend

### DIFF
--- a/frontend/src/components/PlayerStats.vue
+++ b/frontend/src/components/PlayerStats.vue
@@ -96,6 +96,7 @@ import {
   advancedPitchingFields,
   fieldLabels
 } from '../config/playerStatsConfig.js';
+import { fetchPlayerStats, fetchTeamDetails } from '../services/api.js';
 
 
 const { id } = defineProps({ id: String });
@@ -104,15 +105,8 @@ const stats = ref(null);
 const teamAbbrevs = ref({});
 
 onMounted(async () => {
-  try {
-    const resp = await fetch(`/api/players/${id}/stats/`);
-    if (resp.ok) {
-      stats.value = await resp.json();
-      await fetchTeamAbbrevs(stats.value?.stats);
-    }
-  } catch (e) {
-    console.error('Failed to fetch player stats', e);
-  }
+  stats.value = await fetchPlayerStats(id);
+  await fetchTeamAbbrevs(stats.value?.stats);
 });
 
 
@@ -128,14 +122,9 @@ async function fetchTeamAbbrevs(statGroups) {
   await Promise.all(
     Array.from(ids).map(async tid => {
       if (teamAbbrevs.value[tid]) return;
-      try {
-        const resp = await fetch(`/api/teams/${tid}/`);
-        if (resp.ok) {
-          const data = await resp.json();
-          teamAbbrevs.value[tid] = data.abbrev || tid;
-        }
-      } catch (e) {
-        console.error('Failed to fetch team info', e);
+      const data = await fetchTeamDetails(tid);
+      if (data) {
+        teamAbbrevs.value[tid] = data.abbrev || tid;
       }
     })
   );

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,0 +1,80 @@
+const cache = new Map();
+
+async function apiFetch(url, { cacheKey, useCache = true, asText = false } = {}) {
+  if (useCache && cacheKey && cache.has(cacheKey)) {
+    return cache.get(cacheKey);
+  }
+  try {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = asText ? await res.text() : await res.json();
+    if (useCache && cacheKey) {
+      cache.set(cacheKey, data);
+    }
+    return data;
+  } catch (e) {
+    console.error('API fetch failed for', url, e);
+    return null;
+  }
+}
+
+export const fetchTeamDetails = (id, opts) =>
+  apiFetch(`/api/teams/${id}/`, { cacheKey: `team:${id}`, ...opts });
+
+export const fetchTeamLogo = (id, opts) =>
+  apiFetch(`/api/teams/${id}/logo/`, {
+    cacheKey: `teamLogo:${id}`,
+    asText: true,
+    ...opts,
+  });
+
+export const fetchTeamRecord = (id, opts) =>
+  apiFetch(`/api/teams/${id}/record/`, { cacheKey: `teamRecord:${id}`, ...opts });
+
+export const fetchStandings = (opts) =>
+  apiFetch('/api/standings/', { cacheKey: 'standings', ...opts });
+
+export const fetchSchedule = (date, opts) =>
+  apiFetch(`/api/schedule/?date=${date}`, { cacheKey: `schedule:${date}`, ...opts });
+
+export const fetchTopStat = (opts) =>
+  apiFetch('/api/top-stat', { cacheKey: 'topStat', ...opts });
+
+export const fetchPlayer = (id, opts) =>
+  apiFetch(`/api/players/${id}/`, { cacheKey: `player:${id}`, ...opts });
+
+export const fetchPlayerStats = (id, opts) =>
+  apiFetch(`/api/players/${id}/stats/`, { cacheKey: `playerStats:${id}`, ...opts });
+
+export const fetchTeamRecentSchedule = (id, opts) =>
+  apiFetch(`/api/teams/${id}/recent_schedule/`, {
+    cacheKey: `teamRecentSchedule:${id}`,
+    ...opts,
+  });
+
+export const fetchTeamRoster = (id, opts) =>
+  apiFetch(`/api/teams/${id}/roster/`, {
+    cacheKey: `teamRoster:${id}`,
+    ...opts,
+  });
+
+export const fetchTeamLeaders = (id, opts) =>
+  apiFetch(`/api/teams/${id}/leaders/`, {
+    cacheKey: `teamLeaders:${id}`,
+    ...opts,
+  });
+
+export default {
+  fetchTeamDetails,
+  fetchTeamLogo,
+  fetchTeamRecord,
+  fetchStandings,
+  fetchSchedule,
+  fetchTopStat,
+  fetchPlayer,
+  fetchPlayerStats,
+  fetchTeamRecentSchedule,
+  fetchTeamRoster,
+  fetchTeamLeaders,
+};
+

--- a/frontend/src/views/PlayerView.vue
+++ b/frontend/src/views/PlayerView.vue
@@ -85,6 +85,7 @@ import PlayerStats from '../components/PlayerStats.vue';
 import TabView from 'primevue/tabview';
 import TabPanel from 'primevue/tabpanel';
 import teamColors from '../data/teamColors.json';
+import { fetchPlayer, fetchTeamLogo } from '../services/api.js';
 
 const { id } = defineProps({
   id: String
@@ -135,32 +136,21 @@ const hasBio = computed(() =>
 );
 
 onMounted(async () => {
-  try {
-    const resp = await fetch(`/api/players/${id}/`);
-    if (resp.ok) {
-      const data = await resp.json();
-      name.value = data.name || '';
-      teamName.value = data.team_name || '';
-      position.value = data.position || '';
-      birthDate.value = data.birth_date || '';
-      birthPlace.value = data.birth_place || '';
-      height.value = data.height || '';
-      weight.value = data.weight || '';
-      batSide.value = data.bat_side || '';
-      throwSide.value = data.throw_side || '';
-      if (data.team_id) {
-        try {
-          const logoResp = await fetch(`/api/teams/${data.team_id}/logo/`);
-          if (logoResp.ok) {
-            teamLogoSrc.value = (await logoResp.text()).trim();
-          }
-        } catch (e) {
-          console.error('Failed to fetch team logo', e);
-        }
-      }
+  const data = await fetchPlayer(id);
+  if (data) {
+    name.value = data.name || '';
+    teamName.value = data.team_name || '';
+    position.value = data.position || '';
+    birthDate.value = data.birth_date || '';
+    birthPlace.value = data.birth_place || '';
+    height.value = data.height || '';
+    weight.value = data.weight || '';
+    batSide.value = data.bat_side || '';
+    throwSide.value = data.throw_side || '';
+    if (data.team_id) {
+      const logo = await fetchTeamLogo(data.team_id);
+      teamLogoSrc.value = (logo || '').trim();
     }
-  } catch (e) {
-    console.error('Failed to load player info', e);
   }
 });
 </script>


### PR DESCRIPTION
## Summary
- add shared API service with caching and error handling
- refactor HomeView, TeamView, GameRow, PlayerView, and PlayerStats to use new service

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7dc6596c8326b84f4b6f4ffdb177