### PR TITLE
Refactor TeamView into modular subcomponents

### DIFF
--- a/frontend/src/components/team/TeamHeader.vue
+++ b/frontend/src/components/team/TeamHeader.vue
@@ -1,0 +1,141 @@
+<template>
+  <div class="team-header">
+    <div class="top-header">
+      <img v-if="teamLogoSrc" :src="teamLogoSrc" alt="Team Logo" class="team-logo" />
+      <h1 v-if="teamRecord">{{ teamRecord.teamName }}</h1>
+    </div>
+    <div v-if="teamRecord" class="stats-container">
+      <p v-if="teamRecord">
+        {{ teamRecord.wins }}-{{ teamRecord.losses }} - {{ formatRank(teamRecord.divisionRank) }}
+      </p>
+      <table class="team-stats">
+        <thead>
+          <tr>
+            <th>Streak</th>
+            <th>Last 10</th>
+            <th>Last 30</th>
+            <th>RS</th>
+            <th>RA</th>
+            <th>rDiff</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>{{ streakCode }}</td>
+            <td>{{ lastTen }}</td>
+            <td>{{ lastThirty }}</td>
+            <td>{{ runsScored }}</td>
+            <td>{{ runsAllowed }}</td>
+            <td>{{ runDifferential }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const { teamLogoSrc, teamRecord } = defineProps({
+  teamLogoSrc: { type: String, default: '' },
+  teamRecord: { type: Object, default: null }
+});
+
+function formatRank(rank) {
+  if (rank == null) return '';
+  const j = rank % 10;
+  const k = rank % 100;
+  if (j === 1 && k !== 11) return `${rank}st Place`;
+  if (j === 2 && k !== 12) return `${rank}nd Place`;
+  if (j === 3 && k !== 13) return `${rank}rd Place`;
+  return `${rank}th Place`;
+}
+
+const streakCode = computed(() => teamRecord?.streak?.streakCode || '');
+
+const lastTen = computed(() => {
+  const split = teamRecord?.records?.splitRecords?.find(r => r.type === 'lastTen');
+  return split ? `${split.wins}-${split.losses}` : '';
+});
+
+const lastThirty = computed(() => {
+  const split = teamRecord?.records?.splitRecords?.find(r => r.type === 'lastThirty');
+  return split ? `${split.wins}-${split.losses}` : '';
+});
+
+const runsScored = computed(() => teamRecord?.runsScored ?? '');
+const runsAllowed = computed(() => teamRecord?.runsAllowed ?? '');
+const runDifferential = computed(() => teamRecord?.runDifferential ?? '');
+</script>
+
+<style scoped>
+.team-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 1rem;
+  padding: 3rem;
+  font-family: var(--font-base);
+  margin: 0 auto;
+  max-width: 1100px;
+  width: 100%;
+  text-align: center;
+}
+
+.team-logo {
+  max-width: 7.5rem;
+  width: 100%;
+  height: auto;
+}
+
+.stats-container {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  margin: 0 auto 2rem;
+  max-width: 100%;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.stats-container:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+}
+
+.team-stats {
+  border-collapse: collapse;
+  font-family: var(--font-base);
+  font-size: 1.6rem;
+  width: 100%;
+}
+
+.team-stats th,
+.team-stats td {
+  border: 2px solid var(--color-accent);
+  padding: 0.5rem 1rem;
+  text-align: center;
+}
+
+.team-stats th {
+  background-color: var(--color-accent);
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+.team-header .team-stats th {
+  color: white;
+}
+
+@media (max-width: 600px) {
+  .team-header {
+    flex-direction: column;
+    padding: 1.5rem 1rem;
+  }
+
+  .team-logo {
+    margin-right: 0;
+    margin-bottom: 1rem;
+  }
+}
+</style>

--- a/frontend/src/components/team/TeamLeaders.vue
+++ b/frontend/src/components/team/TeamLeaders.vue
@@ -1,0 +1,69 @@
+<template>
+  <div v-if="leaders" class="leader-cards">
+    <div v-if="leaders.batting || leaders.pitching" class="leaders-section">
+      <div v-if="leaders.batting" class="stats-container">
+        <h2>Batting Leaders</h2>
+        <ul>
+          <li v-for="(data, stat) in leaders.batting" :key="`bat-` + stat">
+            {{ stat }}:
+            <RouterLink :to="{ name: 'Player', params: { id: data.id }, query: { name: data.name } }">
+              {{ data.name }}
+            </RouterLink>
+            {{ ['AVG', 'SLG', 'OPS'].includes(stat) && data.value != null
+              ? parseFloat(data.value).toFixed(3).replace(/^0\./, '.')
+              : data.value }}
+          </li>
+        </ul>
+      </div>
+      <div v-if="leaders.pitching" class="stats-container">
+        <h2>Pitching Leaders</h2>
+        <ul>
+          <li v-for="(data, stat) in leaders.pitching" :key="`pit-` + stat">
+            {{ stat }}:
+            <RouterLink :to="{ name: 'Player', params: { id: data.id }, query: { name: data.name } }">
+              {{ data.name }}
+            </RouterLink>
+            {{ stat === 'ERA' && data.value != null
+              ? parseFloat(data.value).toFixed(2)
+              : data.value }}
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <div v-else class="leader-cards">
+    <Skeleton v-for="n in 2" :key="n" width="45%" height="10rem" />
+  </div>
+</template>
+
+<script setup>
+import Skeleton from 'primevue/skeleton';
+
+const { leaders } = defineProps({
+  leaders: { type: Object, default: null }
+});
+</script>
+
+<style scoped>
+.leader-cards {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+}
+
+.stats-container {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  margin: 0 auto 2rem;
+  max-width: 100%;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.stats-container:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+}
+</style>

--- a/frontend/src/components/team/TeamRoster.vue
+++ b/frontend/src/components/team/TeamRoster.vue
@@ -1,0 +1,187 @@
+<template>
+  <div v-if="batters.length || pitchers.length" class="roster-section">
+    <div v-if="batters.length" class="stats-container roster">
+      <h2>Batters ({{ batters.length }})</h2>
+      <table class="team-stats roster-table">
+        <thead class="roster-head">
+          <tr>
+            <th>Name</th>
+            <th>Age</th>
+            <th>Pos</th>
+            <th>Bats</th>
+            <th>#</th>
+            <th>MLB ID</th>
+          </tr>
+        </thead>
+        <tbody>
+          <template v-for="group in battersByPosition" :key="group.position">
+            <tr class="position-row">
+              <th colspan="6">{{ group.position }}</th>
+            </tr>
+            <tr v-for="player in group.players" :key="player.person.id">
+              <td>
+                <RouterLink :to="{ name: 'Player', params: { id: player.person.id } }">
+                  {{ player.person.fullName }}
+                </RouterLink>
+              </td>
+              <td>{{ player.person?.currentAge ?? '' }}</td>
+              <td>{{ player.position.abbreviation }}</td>
+              <td>{{ player.person?.batSide?.code ?? '' }}</td>
+              <td>{{ player.person?.primaryNumber ?? '' }}</td>
+              <td>
+                <a :href="`https://www.mlb.com/player/${player.person.id}`" target="_blank" rel="noopener noreferrer">
+                  {{ player.person.id ?? '' }}
+                </a>
+              </td>
+            </tr>
+          </template>
+        </tbody>
+      </table>
+    </div>
+    <div v-if="pitchers.length" class="stats-container roster">
+      <h2>Pitchers ({{ pitchers.length }})</h2>
+      <table class="team-stats roster-table">
+        <thead class="roster-head">
+          <tr>
+            <th>Name</th>
+            <th>Age</th>
+            <th>Throws</th>
+            <th>#</th>
+            <th>MLB ID</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="player in pitchers" :key="player.person.id">
+            <td>
+              <RouterLink :to="{ name: 'Player', params: { id: player.person.id } }">
+                {{ player.person.fullName }}
+              </RouterLink>
+            </td>
+            <td>{{ player.person?.currentAge ?? '' }}</td>
+            <td>{{ player.person?.pitchHand?.code ?? '' }}</td>
+            <td>{{ player.person?.primaryNumber ?? '' }}</td>
+            <td>
+              <a :href="`https://www.mlb.com/player/${player.person.id}`" target="_blank" rel="noopener noreferrer">
+                {{ player.person.id ?? '' }}
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div v-else class="roster-section">
+    <Skeleton v-for="n in 2" :key="n" class="stats-container roster" height="15rem" />
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import Skeleton from 'primevue/skeleton';
+
+const { roster } = defineProps({
+  roster: { type: Array, default: () => [] }
+});
+
+const batters = computed(() =>
+  roster.filter(p => p.position?.abbreviation !== 'P')
+);
+
+const pitchers = computed(() =>
+  roster.filter(p => p.position?.abbreviation === 'P')
+);
+
+const battersByPosition = computed(() => {
+  const order = ['C', '1B', '2B', '3B', 'SS', 'LF', 'CF', 'RF', 'OF', 'DH'];
+  const groups = batters.value.reduce((acc, player) => {
+    const pos = player.position?.abbreviation || 'Other';
+    if (!acc[pos]) acc[pos] = [];
+    acc[pos].push(player);
+    return acc;
+  }, {});
+  return Object.keys(groups)
+    .sort((a, b) => {
+      const ai = order.indexOf(a);
+      const bi = order.indexOf(b);
+      if (ai === -1 && bi === -1) return a.localeCompare(b);
+      if (ai === -1) return 1;
+      if (bi === -1) return -1;
+      return ai - bi;
+    })
+    .map(pos => ({
+      position: pos,
+      players: groups[pos].sort((a, b) =>
+        (a.person?.fullName ?? '').localeCompare(b.person?.fullName ?? '')
+      ),
+    }));
+});
+</script>
+
+<style scoped>
+.roster-section {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.stats-container {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  margin: 0 auto 2rem;
+  max-width: 100%;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.stats-container:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+}
+
+.roster {
+  flex: 1 1 45%;
+  margin: 0 auto 1rem;
+  padding: 0.5rem;
+}
+
+.team-stats {
+  border-collapse: collapse;
+  font-family: var(--font-base);
+  font-size: 1.6rem;
+  width: 100%;
+}
+
+.team-stats th,
+.team-stats td {
+  border: 2px solid var(--color-accent);
+  padding: 0.5rem 1rem;
+  text-align: center;
+}
+
+.team-stats th {
+  background-color: var(--color-accent);
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+.roster-table {
+  font-size: 1.2rem;
+}
+
+.roster-table th,
+.roster-table td {
+  padding: 0.25rem 0.5rem;
+}
+
+.position-row th {
+  background-color: var(--color-secondary);
+  color: #fff;
+  text-align: left;
+}
+
+.roster-head tr th {
+  color: white;
+}
+</style>

--- a/frontend/src/components/team/TeamSchedule.vue
+++ b/frontend/src/components/team/TeamSchedule.vue
@@ -1,0 +1,117 @@
+<template>
+  <div class="recent-schedule" v-if="recentSchedule">
+    <div class="schedule-section">
+      <h2>Previous Games</h2>
+      <div class="schedule-card">
+        <ul>
+          <li v-for="game in previousGames" :key="`prev-` + game.gamePk">
+            <RouterLink :to="{ name: 'Game', params: { game_pk: game.gamePk } }">
+              {{ formatDate(game.gameDate) }} {{ describeGame(game, true) }}
+            </RouterLink>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <div class="schedule-section">
+      <h2>Upcoming Games</h2>
+      <div class="schedule-card">
+        <ul>
+          <li v-for="game in nextGames" :key="`next-` + game.gamePk">
+            {{ formatDate(game.gameDate) }} {{ describeGame(game, false) }}
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <div v-else class="recent-schedule">
+    <Skeleton v-for="n in 2" :key="n" class="schedule-card" height="8rem" width="45%" />
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import Skeleton from 'primevue/skeleton';
+
+const { recentSchedule, mlbamTeamId } = defineProps({
+  recentSchedule: { type: Object, default: null },
+  mlbamTeamId: { type: [String, Number], required: true }
+});
+
+const previousGames = computed(() => {
+  const dates = recentSchedule?.previousGameSchedule?.dates ?? [];
+  return dates.flatMap(d => d.games);
+});
+
+const nextGames = computed(() => {
+  const dates = recentSchedule?.nextGameSchedule?.dates ?? [];
+  return dates.flatMap(d => d.games);
+});
+
+function formatDate(dateStr) {
+  const d = new Date(dateStr);
+  return isNaN(d) ? dateStr : d.toLocaleDateString();
+}
+
+function describeGame(game, includeScore) {
+  const home = game.teams.home;
+  const away = game.teams.away;
+  const teamIdNum = Number(mlbamTeamId);
+  const isHome = home.team.id === teamIdNum;
+  const opponent = isHome ? away.team.name : home.team.name;
+  const vsAt = isHome ? 'vs' : '@';
+  let result = '';
+  if (includeScore && home.score != null && away.score != null) {
+    const usScore = isHome ? home.score : away.score;
+    const oppScore = isHome ? away.score : home.score;
+    const outcome = usScore > oppScore ? 'W' : (usScore < oppScore ? 'L' : 'T');
+    result = ` ${outcome} ${usScore}-${oppScore}`;
+  }
+  return `${vsAt} ${opponent}${result}`;
+}
+</script>
+
+<style scoped>
+.recent-schedule {
+  display: flex;
+  margin: 1rem auto 0;
+  justify-content: space-between;
+  width: 100%;
+  max-width: 700px;
+  flex-wrap: wrap;
+}
+
+.schedule-section {
+  margin: 1rem 0;
+  flex: 1 1 45%;
+}
+
+.schedule-card {
+  background: rgba(255, 255, 255, 0.1);
+  padding: 1rem;
+  border-radius: 0.5rem;
+  margin-top: 1rem;
+  text-align: left;
+  width: 325px;
+}
+
+.schedule-card ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.schedule-card li {
+  margin-bottom: 0.25rem;
+}
+
+@media (max-width: 600px) {
+  .recent-schedule {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .schedule-section {
+    width: 100%;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- Split TeamView into TeamHeader, TeamLeaders, TeamRoster, and TeamSchedule subcomponents
- Centralized data fetching in TeamView and passed state to subcomponents via props
- Scoped styles moved into each new component for better maintainability

## Testing
- `npm test` *(fails: No test files found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68ae86ca70cc832694ea1613ee472948