### PR TITLE
Fix card text color on GameView

### DIFF
--- a/frontend/src/views/GameView.vue
+++ b/frontend/src/views/GameView.vue
@@ -318,6 +318,7 @@ function playerSeasonStat(side, id, statType, field) {
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   padding: 16px;
   margin-bottom: 20px;
+  color: #000;
 }
 
 .game-date {


### PR DESCRIPTION
## Summary
- ensure GameView cards use black text to remain visible against white backgrounds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae965d1f708326a2b1ecd6ea999cf3