### PR TITLE
Fix card text color on GameView

### DIFF
--- a/frontend/src/views/GameView.vue
+++ b/frontend/src/views/GameView.vue
@@ -217,7 +217,6 @@ function playerSeasonStat(side, id, statType, field) {
 .game-view {
   min-height: 100vh;
   background: linear-gradient(135deg, var(--color-primary), var(--color-secondary));
-  color: #fff;
   padding: 2rem 1rem;
 }
 
@@ -250,6 +249,7 @@ function playerSeasonStat(side, id, statType, field) {
 .linescore td {
   border: 1px solid #ccc;
   text-align: center;
+  color: #000;
 }
 
 .linescore th {
@@ -299,6 +299,7 @@ function playerSeasonStat(side, id, statType, field) {
 .boxscore-table td {
   border: 1px solid #ccc;
   text-align: center;
+  color: #000;
 }
 
 .boxscore-table th {
@@ -318,6 +319,7 @@ function playerSeasonStat(side, id, statType, field) {
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   padding: 16px;
   margin-bottom: 20px;
+  color: #000;
 }
 
 .game-date {


### PR DESCRIPTION
## Summary
- remove inherited white text from GameView root so card content isn't invisible
- force linescore and boxscore table cells to render in black

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae965d1f708326a2b1ecd6ea999cf3