### PR TITLE
feat: add expandable JSON viewer to API explorer

### DIFF
--- a/frontend/src/components/JsonViewer.vue
+++ b/frontend/src/components/JsonViewer.vue
@@ -1,0 +1,59 @@
+<template>
+  <div class="json-node">
+    <template v-if="isObject">
+      <template v-if="hasLabel">
+        <details>
+          <summary>{{ label }}</summary>
+          <ul>
+            <li v-for="(v, k) in data" :key="k">
+              <JsonViewer :data="v" :label="k" />
+            </li>
+          </ul>
+        </details>
+      </template>
+      <template v-else>
+        <ul>
+          <li v-for="(v, k) in data" :key="k">
+            <JsonViewer :data="v" :label="k" />
+          </li>
+        </ul>
+      </template>
+    </template>
+    <template v-else>
+      <span>
+        <strong v-if="hasLabel">{{ label }}: </strong>{{ formattedValue }}
+      </span>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+defineOptions({ name: 'JsonViewer' });
+
+const props = defineProps({
+  data: { type: [Object, Array, String, Number, Boolean, null], required: true },
+  label: { type: [String, Number], default: '' }
+});
+
+const isObject = computed(() => typeof props.data === 'object' && props.data !== null);
+const hasLabel = computed(() => props.label !== '' && props.label !== null);
+const formattedValue = computed(() => JSON.stringify(props.data));
+</script>
+
+<style scoped>
+ul {
+  list-style: none;
+  padding-left: 1rem;
+}
+
+summary {
+  cursor: pointer;
+}
+
+span {
+  font-family: monospace;
+}
+</style>
+

--- a/frontend/src/views/ApiExplorerView.vue
+++ b/frontend/src/views/ApiExplorerView.vue
@@ -22,7 +22,8 @@
               <button @click="callEndpoint">Fetch</button>
             </div>
             <div v-if="result">
-              <pre v-if="resultType === 'json' || resultType === 'text'">{{ result }}</pre>
+              <JsonViewer v-if="resultType === 'json'" :data="result" />
+              <pre v-else-if="resultType === 'text'">{{ result }}</pre>
               <img v-else-if="resultType === 'image'" :src="result" alt="Response image" />
               <a v-else :href="result" download>Download result</a>
             </div>
@@ -47,7 +48,8 @@
                 <button @click="callBackend">Fetch</button>
               </div>
             <div v-if="backendResult">
-              <pre v-if="backendResultType === 'json' || backendResultType === 'text'">{{ backendResult }}</pre>
+              <JsonViewer v-if="backendResultType === 'json'" :data="backendResult" />
+              <pre v-else-if="backendResultType === 'text'">{{ backendResult }}</pre>
               <img v-else-if="backendResultType === 'image'" :src="backendResult" alt="Response image" />
               <a v-else :href="backendResult" download>Download result</a>
             </div>
@@ -82,6 +84,7 @@
 </template>
 <script setup>
 import { ref, onMounted, watch, computed } from 'vue';
+import JsonViewer from '../components/JsonViewer.vue';
 
 const endpoints = ref([]);
 const selected = ref(null);
@@ -195,8 +198,7 @@ async function callEndpoint() {
   const contentType = resp.headers.get('Content-Type') || '';
   resultType.value = '';
   if (contentType.includes('application/json')) {
-    const data = await resp.json();
-    result.value = JSON.stringify(data, null, 2);
+    result.value = await resp.json();
     resultType.value = 'json';
   } else if (contentType.startsWith('text/')) {
     result.value = await resp.text();
@@ -226,8 +228,7 @@ async function callBackend() {
   const contentType = resp.headers.get('Content-Type') || '';
   backendResultType.value = '';
   if (contentType.includes('application/json')) {
-    const data = await resp.json();
-    backendResult.value = JSON.stringify(data, null, 2);
+    backendResult.value = await resp.json();
     backendResultType.value = 'json';
   } else if (contentType.startsWith('text/')) {
     backendResult.value = await resp.text();


### PR DESCRIPTION
## Summary
- add recursive JsonViewer component for interactive JSON display
- show API Explorer responses with expandable tree view
- parse JSON responses into objects before rendering

## Testing
- `npm test`
- `cd backend && pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af62c086c4832681f44f917a50f1f5