### PR TITLE
Use live feed for game data

### DIFF
--- a/backend/apps/api/tests.py
+++ b/backend/apps/api/tests.py
@@ -37,30 +37,29 @@ class GameDataApiTests(TestCase):
     @patch('apps.api.views.UnifiedDataClient')
     def test_game_data_endpoint(self, mock_client_cls):
         mock_client = mock_client_cls.return_value
-        mock_client.get_game_data.return_value = {
+        mock_client.get_game_live_feed.return_value = {
             'teams': {
                 'home': {'team': {'name': 'Home'}, 'score': 5},
                 'away': {'team': {'name': 'Away'}, 'score': 3},
             },
             'home_team_data': {'id': 1},
             'away_team_data': {'id': 2},
+            'liveData': {
+                'boxscore': {'info': [{'label': 'Att', 'value': '10,000'}]}
+            },
         }
         mock_client.get_team_spot_url.return_value = 'logo-url'
-        mock_client.get_game_boxscore_data.return_value = {
-            'info': [{'label': 'Att', 'value': '10,000'}]
-        }
         client = Client()
         response = client.get('/api/games/123/')
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(data['teams']['home']['team']['name'], 'Home')
         self.assertEqual(data['teams']['away']['score'], 3)
-        # boxscore data should be merged into liveData
+        # boxscore data should be present in liveData
         self.assertEqual(
             data['liveData']['boxscore']['info'][0]['label'],
             'Att',
         )
-        mock_client.get_game_boxscore_data.assert_called_once_with(123)
 
 
 class StandingsApiTests(TestCase):

--- a/backend/apps/api/views.py
+++ b/backend/apps/api/views.py
@@ -98,15 +98,13 @@ def game_data(request, game_pk: int):
         return JsonResponse({'error': 'baseball-data-lab library is not installed'}, status=500)
     try:
         client = UnifiedDataClient()
-        data = client.get_game_data(game_pk)
-        # Pull additional boxscore details for summary information
-        try:
-            boxscore = client.get_game_boxscore_data(game_pk)
-            data.setdefault('liveData', {})['boxscore'] = boxscore
-        except Exception:  # pragma: no cover - downstream service failure
-            pass
-        data['home_team_data']['logo_url'] = client.get_team_spot_url(data['home_team_data']['id'], 32)
-        data['away_team_data']['logo_url'] = client.get_team_spot_url(data['away_team_data']['id'], 32)
+        data = client.get_game_live_feed(game_pk)
+        data['home_team_data']['logo_url'] = client.get_team_spot_url(
+            data['home_team_data']['id'], 32
+        )
+        data['away_team_data']['logo_url'] = client.get_team_spot_url(
+            data['away_team_data']['id'], 32
+        )
         return JsonResponse(data, safe=False)
     except Exception as exc:  # pragma: no cover - defensive
         return JsonResponse({'error': str(exc)}, status=500)
@@ -126,7 +124,7 @@ def predict_game(request, game_pk: int):
 
     try:
         client = UnifiedDataClient()
-        game_data = client.get_game_data(game_pk)
+        game_data = client.get_game_live_feed(game_pk)
 
         home_id = game_data.get('home_team_data', {}).get('id')
         away_id = game_data.get('away_team_data', {}).get('id')


### PR DESCRIPTION
## Summary
- Retrieve game details via `get_game_live_feed` instead of `get_game_data`
- Update game prediction endpoint and tests for new live feed method

## Testing
- `npm test`
- `python manage.py test` *(fails: connection to server at "db.tigrhjeznfdtpjfgwane.supabase.co" (2600:1f16:1cd0:3303:c800:dd62:69fe:c11), port 5432 failed: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68af6c8549e483268a325b0359eb8919