### PR TITLE
fix: make API explorer sample IDs scroll independently

### DIFF
--- a/frontend/src/views/ApiExplorerView.vue
+++ b/frontend/src/views/ApiExplorerView.vue
@@ -267,8 +267,9 @@ async function callBackend() {
 <style scoped>
 .api-explorer-wrapper {
   display: flex;
-  flex-direction: row;;
+  flex-direction: row;
   justify-content: space-around;
+  align-items: flex-start;
 }
 
 .api-explorer {
@@ -286,6 +287,10 @@ async function callBackend() {
 .explorer-sidebar {
   margin-left: 2rem;
   max-width: 250px;
+  position: sticky;
+  top: 0;
+  max-height: 100vh;
+  overflow-y: auto;
 }
 
 .explorer-sidebar ul {


### PR DESCRIPTION
## Summary
- keep API Explorer sidebar from stretching with main content
- allow Sample IDs list to scroll separately from main page

## Testing
- `npm test`
- `python manage.py test --settings=baseball_data_lab_web.settings.test` *(fails: OperationalError: connection to server at "db.tigrhjeznfdtpjfgwane.supabase.co" port 5432 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68af71bbc3688326af2f6c20a42e5e80