### PR TITLE
Fix homerun summary display

### DIFF
--- a/frontend/src/views/GameView.vue
+++ b/frontend/src/views/GameView.vue
@@ -208,13 +208,17 @@ const savePitcher = computed(() => {
 });
 
 const homers = computed(() => {
-  const fromSummary = game.value?.summary?.homers;
-  if (fromSummary && fromSummary.length) {
-    return fromSummary.join(', ');
+  const entries = [];
+  for (const side of ['away', 'home']) {
+    const batters = boxscoreTeams.value[side]?.batters ?? [];
+    for (const id of batters) {
+      const hr = playerStat(side, id, 'batting', 'homeRuns');
+      if (hr && Number(hr) > 0) {
+        entries.push(`${playerName(side, id)} (${hr})`);
+      }
+    }
   }
-  const info = boxscore.value?.info ?? [];
-  const hrEntry = info.find(item => item.label === 'HR');
-  return hrEntry ? hrEntry.value : '—';
+  return entries.length ? entries.join(', ') : '—';
 });
 
 const attendance = computed(() => {


### PR DESCRIPTION
## Summary
- compute homerun hitters from boxscore data so summary shows player names with HR counts

## Testing
- `npm test`
- `python manage.py test` *(fails: connection to server at "localhost" (127.0.0.1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68af7a06e8fc83268d1f6d4802e7590e