### PR TITLE
Use consistent team logos in GameView top performers

### DIFF
--- a/frontend/src/views/GameView.vue
+++ b/frontend/src/views/GameView.vue
@@ -198,6 +198,13 @@ function performerSummary(tp) {
 }
 
 function teamLogo(tp) {
+  const teamId = tp?.team?.id;
+  if (teamId === homeTeam.value?.id) {
+    return homeTeam.value?.logo_url || '';
+  }
+  if (teamId === awayTeam.value?.id) {
+    return awayTeam.value?.logo_url || '';
+  }
   return tp?.team?.logo_url || tp?.team?.logo || '';
 }
 


### PR DESCRIPTION
## Summary
- Match top performer team logos to the ones in the matchup header for GameView

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af8b1830b08326bff4713839257980