### PR TITLE
Link live schedule games to GameView

### DIFF
--- a/frontend/src/components/GameRow.vue
+++ b/frontend/src/components/GameRow.vue
@@ -29,10 +29,10 @@
     </div>
     <div class="game-time">
       <RouterLink
-        v-if="game.status?.detailedState === 'Final'"
+        v-if="game.status?.detailedState === 'Final' || game.status?.abstractGameState === 'Live'"
         :to="{ name: 'Game', params: { game_pk: game.gamePk } }"
       >
-        Final
+        {{ gameTime(game) }}
       </RouterLink>
       <span v-else>{{ gameTime(game) }}</span>
     </div>


### PR DESCRIPTION
## Summary
- link live games in the schedule to their GameView page

## Testing
- `npm test`
- `python backend/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68afaefe69a483269090d031fffb016e