### PR TITLE
feat: show pitch count for pitchers in GameView boxscore

### DIFF
--- a/frontend/src/views/GameView.vue
+++ b/frontend/src/views/GameView.vue
@@ -163,6 +163,7 @@
                   <th>ER</th>
                   <th>BB</th>
                   <th>K</th>
+                  <th>PC</th>
                   <th>ERA</th>
                 </tr>
               </thead>
@@ -175,6 +176,7 @@
                   <td>{{ playerStat(side, id, 'pitching', 'earnedRuns') }}</td>
                   <td>{{ playerStat(side, id, 'pitching', 'baseOnBalls') }}</td>
                   <td>{{ playerStat(side, id, 'pitching', 'strikeOuts') }}</td>
+                  <td>{{ playerStat(side, id, 'pitching', 'numberOfPitches') }}</td>
                   <td>{{ playerSeasonStat(side, id, 'pitching', 'era') }}</td>
                 </tr>
               </tbody>


### PR DESCRIPTION
## Summary
- show pitch count (PC) for each pitcher in the GameView boxscore

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afb002c2cc8326ae55d3e5adb5209f