### PR TITLE
Add Leaders page and nav entry

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -6,6 +6,7 @@
       <RouterLink to="/standings">Standings</RouterLink>
       <RouterLink to="/teams">Teams</RouterLink>
       <RouterLink to="/players">Players</RouterLink>
+      <RouterLink to="/leaders">Leaders</RouterLink>
       <RouterLink to="/developer" class="developer-link">Developer</RouterLink>
     </nav>
     <router-view />

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -39,6 +39,11 @@ const routes = [
     component: () => import('../views/PlayersView.vue')
   },
   {
+    path: '/leaders',
+    name: 'Leaders',
+    component: () => import('../views/LeadersView.vue')
+  },
+  {
     path: '/player/:id',
     name: 'Player',
     component: () => import('../views/PlayerView.vue'),

--- a/frontend/src/views/LeadersView.vue
+++ b/frontend/src/views/LeadersView.vue
@@ -1,0 +1,76 @@
+<template>
+  <section class="leaders-view">
+    <div class="leaders-content">
+      <h1>League Leaders</h1>
+      <div class="leaders-lists">
+        <PlayerQuickList
+          v-if="leaders?.batting?.HR"
+          title="HR Leaders"
+          :players="leaders.batting.HR"
+        />
+        <PlayerQuickList
+          v-if="leaders?.batting?.AVG"
+          title="AVG Leaders"
+          :players="leaders.batting.AVG"
+        />
+        <PlayerQuickList
+          v-if="leaders?.batting?.OPS"
+          title="OPS Leaders"
+          :players="leaders.batting.OPS"
+        />
+        <PlayerQuickList
+          v-if="leaders?.pitching?.ERA"
+          title="ERA Leaders"
+          :players="leaders.pitching.ERA"
+          :decimal-places="2"
+        />
+        <PlayerQuickList
+          v-if="leaders?.pitching?.SO"
+          title="SO Leaders"
+          :players="leaders.pitching.SO"
+        />
+        <PlayerQuickList
+          v-if="leaders?.pitching?.WHIP"
+          title="WHIP Leaders"
+          :players="leaders.pitching.WHIP"
+          :decimal-places="2"
+        />
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { onMounted, ref } from 'vue';
+import PlayerQuickList from '../components/PlayerQuickList.vue';
+
+const leaders = ref(null);
+
+onMounted(async () => {
+  try {
+    const res = await fetch('/api/leaders/');
+    leaders.value = await res.json();
+  } catch (e) {
+    console.error('Failed to fetch league leaders:', e);
+    leaders.value = null;
+  }
+});
+</script>
+
+<style scoped>
+.leaders-view {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}
+
+.leaders-content {
+  max-width: 1100px;
+}
+
+.leaders-lists {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+}
+</style>


### PR DESCRIPTION
## Summary
- include new Leaders navigation item and route
- implement LeadersView displaying batting and pitching leaders

## Testing
- `npm test`
- `DJANGO_SETTINGS_MODULE=baseball_data_lab_web.settings.test python manage.py test` *(fails: connection to server at "db.tigrhjeznfdtpjfgwane.supabase.co" (port 5432) failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68afb1d1b5dc83269c587adc1cc291e2