### PR TITLE
Configure static file collection

### DIFF
--- a/backend/baseball_data_lab_web/settings/base.py
+++ b/backend/baseball_data_lab_web/settings/base.py
@@ -89,6 +89,7 @@ USE_I18N = True
 USE_TZ = True
 
 STATIC_URL = '/static/'
+STATIC_ROOT = BASE_DIR / "staticfiles"
 STATICFILES_DIRS = [BASE_DIR / 'static']
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'

--- a/backend/staticfiles/.gitignore
+++ b/backend/staticfiles/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,3 @@
 pip install -r backend/requirements.txt \
  && cd frontend && npm ci && npm run build && cd .. \
- && python backend/manage.py collectstatic --noinput
+ && DJANGO_SETTINGS_MODULE=baseball_data_lab_web.settings.prod python backend/manage.py collectstatic --noinput


### PR DESCRIPTION
## Summary
- add STATIC_ROOT for collected assets
- use production settings when running collectstatic
- ensure staticfiles directory exists and is ignored

## Testing
- `python backend/manage.py check --settings=baseball_data_lab_web.settings.prod`
- `python backend/manage.py test --settings=baseball_data_lab_web.settings.test`
- `python backend/manage.py collectstatic --noinput --settings=baseball_data_lab_web.settings.prod`

------
https://chatgpt.com/codex/tasks/task_e_68afb82051d883269e86bd65f73af4b2