### PR TITLE
Use environment variables for settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+SECRET_KEY=change-me
+POSTGRES_DB=baseball_web_dev
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_HOST=localhost
+POSTGRES_PORT=5432

--- a/README.md
+++ b/README.md
@@ -26,6 +26,19 @@ A Django based web interface for exploring data from the `baseball-data-lab` lib
    ```
 5. Visit `http://localhost:8000/` to see the home page displaying information from `baseball-data-lab`.
 
+### Environment Variables
+
+Configuration values are read from environment variables. Copy `.env.example` to `.env` and adjust as needed.
+
+| Variable | Description |
+| --- | --- |
+| `SECRET_KEY` | Django secret key |
+| `POSTGRES_DB` | Database name |
+| `POSTGRES_USER` | Database user |
+| `POSTGRES_PASSWORD` | Database password |
+| `POSTGRES_HOST` | Database host |
+| `POSTGRES_PORT` | Database port |
+
 This project is a minimal scaffold and is intended to grow with additional views and data presentations over time.
 
 ## Frontend

--- a/backend/baseball_data_lab_web/settings/base.py
+++ b/backend/baseball_data_lab_web/settings/base.py
@@ -1,5 +1,6 @@
 from pathlib import Path
-import os
+
+from .env import SECRET_KEY, DATABASES
 
 #BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
@@ -9,9 +10,6 @@ BASE_DIR = Path(__file__).resolve().parent.parent.parent
 # STATICFILES_DIRS = [
 #     os.path.join(BASE_DIR, '../frontend', 'dist'), # Assuming 'frontend/dist' is your Vite build output
 # ]
-
-
-SECRET_KEY = 'development-secret-key'
 
 DEBUG = False
 
@@ -60,25 +58,6 @@ TEMPLATES = [
 
 
 WSGI_APPLICATION = 'baseball_data_lab_web.wsgi.application'
-
-# if os.environ.get('POSTGRES_DB'):
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'baseball_web_dev',
-        'USER': '',
-        'PASSWORD': '',
-        'HOST': os.environ.get('POSTGRES_HOST', 'localhost'),
-        'PORT': os.environ.get('POSTGRES_PORT', '5432'),
-    }
-}
-# else:
-#     DATABASES = {
-#         'default': {
-#             'ENGINE': 'django.db.backends.sqlite3',
-#             'NAME': BASE_DIR / 'db.sqlite3',
-#         }
-#     }
 
 LANGUAGE_CODE = 'en-us'
 

--- a/backend/baseball_data_lab_web/settings/env.py
+++ b/backend/baseball_data_lab_web/settings/env.py
@@ -1,0 +1,25 @@
+import os
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
+
+SECRET_KEY = os.environ.get("SECRET_KEY", "development-secret-key")
+
+if os.environ.get("POSTGRES_DB"):
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.postgresql",
+            "NAME": os.environ.get("POSTGRES_DB"),
+            "USER": os.environ.get("POSTGRES_USER", ""),
+            "PASSWORD": os.environ.get("POSTGRES_PASSWORD", ""),
+            "HOST": os.environ.get("POSTGRES_HOST", "localhost"),
+            "PORT": os.environ.get("POSTGRES_PORT", "5432"),
+        }
+    }
+else:
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": BASE_DIR / "db.sqlite3",
+        }
+    }

--- a/backend/baseball_data_lab_web/settings/prod.py
+++ b/backend/baseball_data_lab_web/settings/prod.py
@@ -1,15 +1,6 @@
 from .base import *  # noqa
+from .env import DATABASES as ENV_DATABASES
 
 DEBUG = False
 
-
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'postgres',
-        'USER': 'postgres',
-        'PASSWORD': '3121018Fisher',
-        'HOST': 'db.tigrhjeznfdtpjfgwane.supabase.co',
-        'PORT': 5432,
-    }
-}
+DATABASES = ENV_DATABASES

--- a/backend/baseball_data_lab_web/settings/test.py
+++ b/backend/baseball_data_lab_web/settings/test.py
@@ -1,15 +1,6 @@
 from .base import *  # noqa
+from .env import DATABASES as ENV_DATABASES
 
 DEBUG = False
 
-
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'postgres',
-        'USER': 'postgres',
-        'PASSWORD': '3121018Fisher',
-        'HOST': 'db.tigrhjeznfdtpjfgwane.supabase.co',
-        'PORT': 5432,
-    }
-}
+DATABASES = ENV_DATABASES


### PR DESCRIPTION
## Summary
- load Django secret key and database configuration from environment variables
- replace hard-coded settings with env-based values
- document required environment variables and add `.env.example`

## Testing
- `python backend/manage.py test --settings=baseball_data_lab_web.settings.test`


------
https://chatgpt.com/codex/tasks/task_e_68b07fd468ec83269432006d8876a862