### PR TITLE
refactor: centralize UnifiedDataClient setup

### DIFF
--- a/backend/apps/api/utils.py
+++ b/backend/apps/api/utils.py
@@ -1,0 +1,36 @@
+"""Utility helpers for API views."""
+
+import logging
+from functools import wraps
+from django.http import JsonResponse
+
+logger = logging.getLogger(__name__)
+
+
+def require_unified_client(view_func):
+    """Ensure ``UnifiedDataClient`` is available and provide an instance.
+
+    The decorated view must accept a ``client`` positional argument which will
+    be an instance of ``UnifiedDataClient``. If the client library is missing or
+    the client fails to instantiate, a standardized JSON error response is
+    returned.
+    """
+
+    @wraps(view_func)
+    def _wrapped(request, *args, **kwargs):
+        from . import views as api_views  # Local import to avoid circular deps
+
+        client_cls = getattr(api_views, "UnifiedDataClient", None)
+        if client_cls is None:
+            return JsonResponse(
+                {"error": "baseball-data-lab library is not installed"}, status=500
+            )
+        try:
+            client = client_cls()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("Failed to instantiate UnifiedDataClient: %s", exc)
+            return JsonResponse({"error": str(exc)}, status=500)
+        return view_func(request, client, *args, **kwargs)
+
+    return _wrapped
+

--- a/backend/apps/api/views/__init__.py
+++ b/backend/apps/api/views/__init__.py
@@ -25,6 +25,8 @@ from .teams import (
     team_leaders,
 )
 
+from ..utils import require_unified_client
+
 try:
     from baseball_data_lab.apis.unified_data_client import UnifiedDataClient
     _bdl_error = None
@@ -107,11 +109,9 @@ def news(request):
 
 
 @require_GET
-def unified_client_methods(request):
+@require_unified_client
+def unified_client_methods(request, client):
     """Return a list of ``UnifiedDataClient`` methods and required params."""
-    if UnifiedDataClient is None:
-        return JsonResponse({'error': 'baseball-data-lab library is not installed'}, status=500)
-    client = UnifiedDataClient()
     methods = []
     for name in dir(client):
         if name.startswith('_'):
@@ -137,11 +137,9 @@ def unified_client_methods(request):
 
 
 @require_GET
-def unified_client_call(request, method_name: str):
+@require_unified_client
+def unified_client_call(request, client, method_name: str):
     """Invoke a ``UnifiedDataClient`` method with query parameters."""
-    if UnifiedDataClient is None:
-        return JsonResponse({'error': 'baseball-data-lab library is not installed'}, status=500)
-    client = UnifiedDataClient()
     if not hasattr(client, method_name):
         return JsonResponse({'error': 'method not found'}, status=404)
     method = getattr(client, method_name)


### PR DESCRIPTION
## Summary
- add `require_unified_client` decorator to standardize UnifiedDataClient creation and errors
- apply decorator to API endpoints that previously inlined UnifiedDataClient checks
- ensure optional team info uses shared UnifiedDataClient instance

## Testing
- `DJANGO_SETTINGS_MODULE=baseball_data_lab_web.settings.test python manage.py test apps.api.tests` *(fails: multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b0866013908326aafd0dc8d4bb70ff