### PR TITLE
Add sortable batting leaders table using unified leaderboard data

### DIFF
--- a/backend/apps/api/views/__init__.py
+++ b/backend/apps/api/views/__init__.py
@@ -168,6 +168,11 @@ def unified_client_call(request, client, method_name: str):
         return Response({'error': str(exc)}, status=500)
     if isinstance(result, (dict, list)):
         return Response(result)
+    if hasattr(result, 'to_dict'):
+        try:
+            return Response(result.to_dict(orient='records'))
+        except Exception:  # pragma: no cover - defensive
+            pass
     if isinstance(result, bytes):
         return HttpResponse(result, content_type='application/octet-stream')
     if isinstance(result, str):

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -64,6 +64,22 @@ export const fetchTeamLeaders = (id, opts) =>
     ...opts,
   });
 
+export const fetchBattingLeaders = (
+  season,
+  statType,
+  sortOrder = 'desc',
+  limit = 10,
+  offset = 0,
+  opts,
+) =>
+  apiFetch(
+    `/api/unified/get_leaderboard_data/?season=${season}&group=hitting&stat_type=${statType}&limit=${limit}&offset=${offset}&sort_order=${sortOrder}`,
+    {
+      cacheKey: `battingLeaders:${season}:${statType}:${sortOrder}:${limit}:${offset}`,
+      ...opts,
+    },
+  );
+
 export default {
   fetchTeamDetails,
   fetchTeamLogo,
@@ -76,5 +92,6 @@ export default {
   fetchTeamRecentSchedule,
   fetchTeamRoster,
   fetchTeamLeaders,
+  fetchBattingLeaders,
 };
 

--- a/frontend/src/views/LeadersView.vue
+++ b/frontend/src/views/LeadersView.vue
@@ -2,6 +2,27 @@
   <section class="leaders-view">
     <div class="leaders-content">
       <h1>League Leaders</h1>
+      <h2>Batting Leaders</h2>
+      <DataTable
+        v-if="battingLeaders.length"
+        :value="battingLeaders"
+        class="batting-leaders-table"
+        lazy
+        :sortField="tableSort.field"
+        :sortOrder="tableSort.order"
+        @sort="onTableSort"
+      >
+        <Column field="rank" header="#"></Column>
+        <Column field="playerFullName" header="Player"></Column>
+        <Column field="teamAbbrev" header="Team"></Column>
+        <Column field="avg" header="AVG" sortable></Column>
+        <Column field="homeRuns" header="HR" sortable></Column>
+        <Column field="rbi" header="RBI" sortable></Column>
+        <Column field="ops" header="OPS" sortable></Column>
+        <Column field="stolenBases" header="SB" sortable></Column>
+        <Column field="baseOnBalls" header="BB" sortable></Column>
+        <Column field="strikeOuts" header="SO" sortable></Column>
+      </DataTable>
       <div class="leaders-lists">
         <PlayerQuickList
           v-if="leaders?.batting?.HR"
@@ -43,8 +64,13 @@
 <script setup>
 import { onMounted, ref } from 'vue';
 import PlayerQuickList from '../components/PlayerQuickList.vue';
+import DataTable from 'primevue/datatable';
+import Column from 'primevue/column';
+import { fetchBattingLeaders } from '../services/api';
 
 const leaders = ref(null);
+const battingLeaders = ref([]);
+const tableSort = ref({ field: 'homeRuns', order: -1 });
 
 onMounted(async () => {
   try {
@@ -54,7 +80,27 @@ onMounted(async () => {
     console.error('Failed to fetch league leaders:', e);
     leaders.value = null;
   }
+  await loadBattingLeaders();
 });
+
+async function loadBattingLeaders() {
+  const season = new Date().getFullYear();
+  const order = tableSort.value.order === 1 ? 'asc' : 'desc';
+  const data = await fetchBattingLeaders(
+    season,
+    tableSort.value.field,
+    order,
+    10,
+    0,
+    { useCache: false },
+  );
+  battingLeaders.value = Array.isArray(data) ? data : data?.stats || [];
+}
+
+function onTableSort(e) {
+  tableSort.value = { field: e.sortField, order: e.sortOrder };
+  loadBattingLeaders();
+}
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- add `fetchBattingLeaders` service for UnifiedDataClient leaderboard API
- render batting leaders table on `LeadersView` with server-side sorting
- convert DataFrame results to JSON in `unified_client_call`

## Testing
- `npm test`
- `pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68b62f19dd0083269838a178de3a4dac