### PR TITLE
feat: add leader tabs

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -80,6 +80,38 @@ export const fetchBattingLeaders = (
     },
   );
 
+export const fetchPitchingLeaders = (
+  season,
+  statType,
+  sortOrder = 'asc',
+  limit = 10,
+  offset = 0,
+  opts,
+) =>
+  apiFetch(
+    `/api/unified/get_leaderboard_data/?season=${season}&group=pitching&stat_type=${statType}&limit=${limit}&offset=${offset}&sort_order=${sortOrder}`,
+    {
+      cacheKey: `pitchingLeaders:${season}:${statType}:${sortOrder}:${limit}:${offset}`,
+      ...opts,
+    },
+  );
+
+export const fetchFieldingLeaders = (
+  season,
+  statType,
+  sortOrder = 'desc',
+  limit = 10,
+  offset = 0,
+  opts,
+) =>
+  apiFetch(
+    `/api/unified/get_leaderboard_data/?season=${season}&group=fielding&stat_type=${statType}&limit=${limit}&offset=${offset}&sort_order=${sortOrder}`,
+    {
+      cacheKey: `fieldingLeaders:${season}:${statType}:${sortOrder}:${limit}:${offset}`,
+      ...opts,
+    },
+  );
+
 export default {
   fetchTeamDetails,
   fetchTeamLogo,
@@ -93,5 +125,7 @@ export default {
   fetchTeamRoster,
   fetchTeamLeaders,
   fetchBattingLeaders,
+  fetchPitchingLeaders,
+  fetchFieldingLeaders,
 };
 

--- a/frontend/src/views/LeadersView.vue
+++ b/frontend/src/views/LeadersView.vue
@@ -2,61 +2,105 @@
   <section class="leaders-view">
     <div class="leaders-content">
       <h1>League Leaders</h1>
-      <h2>Batting Leaders</h2>
-      <DataTable
-        v-if="battingLeaders.length"
-        :value="battingLeaders"
-        class="batting-leaders-table"
-        lazy
-        :sortField="tableSort.field"
-        :sortOrder="tableSort.order"
-        @sort="onTableSort"
-      >
-        <Column field="rank" header="#"></Column>
-        <Column field="playerFullName" header="Player"></Column>
-        <Column field="teamAbbrev" header="Team"></Column>
-        <Column field="avg" header="AVG" sortable></Column>
-        <Column field="homeRuns" header="HR" sortable></Column>
-        <Column field="rbi" header="RBI" sortable></Column>
-        <Column field="ops" header="OPS" sortable></Column>
-        <Column field="stolenBases" header="SB" sortable></Column>
-        <Column field="baseOnBalls" header="BB" sortable></Column>
-        <Column field="strikeOuts" header="SO" sortable></Column>
-      </DataTable>
-      <div class="leaders-lists">
-        <PlayerQuickList
-          v-if="leaders?.batting?.HR"
-          title="HR Leaders"
-          :players="leaders.batting.HR"
-        />
-        <PlayerQuickList
-          v-if="leaders?.batting?.AVG"
-          title="AVG Leaders"
-          :players="leaders.batting.AVG"
-        />
-        <PlayerQuickList
-          v-if="leaders?.batting?.OPS"
-          title="OPS Leaders"
-          :players="leaders.batting.OPS"
-        />
-        <PlayerQuickList
-          v-if="leaders?.pitching?.ERA"
-          title="ERA Leaders"
-          :players="leaders.pitching.ERA"
-          :decimal-places="2"
-        />
-        <PlayerQuickList
-          v-if="leaders?.pitching?.SO"
-          title="SO Leaders"
-          :players="leaders.pitching.SO"
-        />
-        <PlayerQuickList
-          v-if="leaders?.pitching?.WHIP"
-          title="WHIP Leaders"
-          :players="leaders.pitching.WHIP"
-          :decimal-places="2"
-        />
-      </div>
+      <TabView>
+        <TabPanel header="Batting Leaders">
+          <DataTable
+            v-if="battingLeaders.length"
+            :value="battingLeaders"
+            class="batting-leaders-table"
+            lazy
+            :sortField="battingSort.field"
+            :sortOrder="battingSort.order"
+            @sort="onBattingSort"
+          >
+            <Column field="rank" header="#"></Column>
+            <Column field="playerFullName" header="Player"></Column>
+            <Column field="teamAbbrev" header="Team"></Column>
+            <Column field="avg" header="AVG" sortable></Column>
+            <Column field="homeRuns" header="HR" sortable></Column>
+            <Column field="rbi" header="RBI" sortable></Column>
+            <Column field="ops" header="OPS" sortable></Column>
+            <Column field="stolenBases" header="SB" sortable></Column>
+            <Column field="baseOnBalls" header="BB" sortable></Column>
+            <Column field="strikeOuts" header="SO" sortable></Column>
+          </DataTable>
+          <div class="leaders-lists">
+            <PlayerQuickList
+              v-if="leaders?.batting?.HR"
+              title="HR Leaders"
+              :players="leaders.batting.HR"
+            />
+            <PlayerQuickList
+              v-if="leaders?.batting?.AVG"
+              title="AVG Leaders"
+              :players="leaders.batting.AVG"
+            />
+            <PlayerQuickList
+              v-if="leaders?.batting?.OPS"
+              title="OPS Leaders"
+              :players="leaders.batting.OPS"
+            />
+          </div>
+        </TabPanel>
+        <TabPanel header="Pitching Leaders">
+          <DataTable
+            v-if="pitchingLeaders.length"
+            :value="pitchingLeaders"
+            class="pitching-leaders-table"
+            lazy
+            :sortField="pitchingSort.field"
+            :sortOrder="pitchingSort.order"
+            @sort="onPitchingSort"
+          >
+            <Column field="rank" header="#"></Column>
+            <Column field="playerFullName" header="Player"></Column>
+            <Column field="teamAbbrev" header="Team"></Column>
+            <Column field="era" header="ERA" sortable></Column>
+            <Column field="wins" header="W" sortable></Column>
+            <Column field="strikeOuts" header="SO" sortable></Column>
+            <Column field="whip" header="WHIP" sortable></Column>
+            <Column field="saves" header="SV" sortable></Column>
+          </DataTable>
+          <div class="leaders-lists">
+            <PlayerQuickList
+              v-if="leaders?.pitching?.ERA"
+              title="ERA Leaders"
+              :players="leaders.pitching.ERA"
+              :decimal-places="2"
+            />
+            <PlayerQuickList
+              v-if="leaders?.pitching?.SO"
+              title="SO Leaders"
+              :players="leaders.pitching.SO"
+            />
+            <PlayerQuickList
+              v-if="leaders?.pitching?.WHIP"
+              title="WHIP Leaders"
+              :players="leaders.pitching.WHIP"
+              :decimal-places="2"
+            />
+          </div>
+        </TabPanel>
+        <TabPanel header="Fielding Leaders">
+          <DataTable
+            v-if="fieldingLeaders.length"
+            :value="fieldingLeaders"
+            class="fielding-leaders-table"
+            lazy
+            :sortField="fieldingSort.field"
+            :sortOrder="fieldingSort.order"
+            @sort="onFieldingSort"
+          >
+            <Column field="rank" header="#"></Column>
+            <Column field="playerFullName" header="Player"></Column>
+            <Column field="teamAbbrev" header="Team"></Column>
+            <Column field="fieldingPercentage" header="FPCT" sortable></Column>
+            <Column field="assists" header="A" sortable></Column>
+            <Column field="putOuts" header="PO" sortable></Column>
+            <Column field="errors" header="E" sortable></Column>
+          </DataTable>
+        </TabPanel>
+      </TabView>
     </div>
   </section>
 </template>
@@ -66,11 +110,22 @@ import { onMounted, ref } from 'vue';
 import PlayerQuickList from '../components/PlayerQuickList.vue';
 import DataTable from 'primevue/datatable';
 import Column from 'primevue/column';
-import { fetchBattingLeaders } from '../services/api';
+import TabView from 'primevue/tabview';
+import TabPanel from 'primevue/tabpanel';
+import {
+  fetchBattingLeaders,
+  fetchPitchingLeaders,
+  fetchFieldingLeaders,
+} from '../services/api';
 
 const leaders = ref(null);
 const battingLeaders = ref([]);
-const tableSort = ref({ field: 'homeRuns', order: -1 });
+const pitchingLeaders = ref([]);
+const fieldingLeaders = ref([]);
+
+const battingSort = ref({ field: 'homeRuns', order: -1 });
+const pitchingSort = ref({ field: 'era', order: 1 });
+const fieldingSort = ref({ field: 'fieldingPercentage', order: -1 });
 
 onMounted(async () => {
   try {
@@ -80,15 +135,19 @@ onMounted(async () => {
     console.error('Failed to fetch league leaders:', e);
     leaders.value = null;
   }
-  await loadBattingLeaders();
+  await Promise.all([
+    loadBattingLeaders(),
+    loadPitchingLeaders(),
+    loadFieldingLeaders(),
+  ]);
 });
 
 async function loadBattingLeaders() {
   const season = new Date().getFullYear();
-  const order = tableSort.value.order === 1 ? 'asc' : 'desc';
+  const order = battingSort.value.order === 1 ? 'asc' : 'desc';
   const data = await fetchBattingLeaders(
     season,
-    tableSort.value.field,
+    battingSort.value.field,
     order,
     10,
     0,
@@ -97,9 +156,47 @@ async function loadBattingLeaders() {
   battingLeaders.value = Array.isArray(data) ? data : data?.stats || [];
 }
 
-function onTableSort(e) {
-  tableSort.value = { field: e.sortField, order: e.sortOrder };
+async function loadPitchingLeaders() {
+  const season = new Date().getFullYear();
+  const order = pitchingSort.value.order === 1 ? 'asc' : 'desc';
+  const data = await fetchPitchingLeaders(
+    season,
+    pitchingSort.value.field,
+    order,
+    10,
+    0,
+    { useCache: false },
+  );
+  pitchingLeaders.value = Array.isArray(data) ? data : data?.stats || [];
+}
+
+async function loadFieldingLeaders() {
+  const season = new Date().getFullYear();
+  const order = fieldingSort.value.order === 1 ? 'asc' : 'desc';
+  const data = await fetchFieldingLeaders(
+    season,
+    fieldingSort.value.field,
+    order,
+    10,
+    0,
+    { useCache: false },
+  );
+  fieldingLeaders.value = Array.isArray(data) ? data : data?.stats || [];
+}
+
+function onBattingSort(e) {
+  battingSort.value = { field: e.sortField, order: e.sortOrder };
   loadBattingLeaders();
+}
+
+function onPitchingSort(e) {
+  pitchingSort.value = { field: e.sortField, order: e.sortOrder };
+  loadPitchingLeaders();
+}
+
+function onFieldingSort(e) {
+  fieldingSort.value = { field: e.sortField, order: e.sortOrder };
+  loadFieldingLeaders();
 }
 </script>
 


### PR DESCRIPTION
## Summary
- add API helpers for pitching and fielding leaderboards
- split LeadersView into Batting, Pitching, and Fielding tabs

## Testing
- `npm test`
- `python manage.py test` *(fails: Internal Server Error, command killed)*

------
https://chatgpt.com/codex/tasks/task_e_68b6330600388326b3e3e856df17b97a