### PR TITLE
Add doubles and triples columns to batting leaders table

### DIFF
--- a/frontend/src/views/LeadersView.vue
+++ b/frontend/src/views/LeadersView.vue
@@ -18,6 +18,8 @@
         <Column field="avg" header="AVG" sortable></Column>
         <Column field="homeRuns" header="HR" sortable></Column>
         <Column field="rbi" header="RBI" sortable></Column>
+        <Column field="doubles" header="2B" sortable></Column>
+        <Column field="triples" header="3B" sortable></Column>
         <Column field="ops" header="OPS" sortable></Column>
         <Column field="stolenBases" header="SB" sortable></Column>
         <Column field="baseOnBalls" header="BB" sortable></Column>


### PR DESCRIPTION
## Summary
- include 2B and 3B columns in batting leaders DataTable for sorting

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6341c066c83269ff2b7bedee4a21a