### PR TITLE
Configure pytest with Django settings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = baseball_data_lab_web.settings.test
+pythonpath = backend


### PR DESCRIPTION
## Summary
- add pytest.ini to configure `DJANGO_SETTINGS_MODULE`

## Testing
- `pytest` *(fails: process killed after several test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b631fbd27883269eaccc9a2f128525