### PR TITLE
feat: add doubles and triples to batting leaders table

### DIFF
--- a/frontend/src/views/LeadersView.vue
+++ b/frontend/src/views/LeadersView.vue
@@ -17,6 +17,8 @@
             <Column field="playerFullName" header="Player"></Column>
             <Column field="teamAbbrev" header="Team"></Column>
             <Column field="avg" header="AVG" sortable></Column>
+            <Column field="doubles" header="2B" sortable></Column>
+            <Column field="triples" header="3B" sortable></Column>
             <Column field="homeRuns" header="HR" sortable></Column>
             <Column field="rbi" header="RBI" sortable></Column>
             <Column field="ops" header="OPS" sortable></Column>


### PR DESCRIPTION
## Summary
- show doubles (2B) and triples (3B) columns in batting leaders table so users can sort by those stats

## Testing
- `npm test --prefix frontend`
- `pytest` *(fails: django.core.exceptions.ImproperlyConfigured: Requested setting INSTALLED_APPS, but settings are not configured.)*

------
https://chatgpt.com/codex/tasks/task_e_68b636dd8950832696d0b702a024f13a