### PR TITLE
feat: add base layout component

### DIFF
--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -52,3 +52,10 @@ a:hover {
 .search-page .search-container .p-inputtext {
   width: 100%;
 }
+
+.page-wrapper {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+

--- a/frontend/src/layouts/BaseLayout.vue
+++ b/frontend/src/layouts/BaseLayout.vue
@@ -1,0 +1,11 @@
+<template>
+  <div class="page-wrapper">
+    <router-view />
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'BaseLayout'
+};
+</script>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,58 +1,65 @@
 import { createRouter, createWebHistory } from 'vue-router';
+import BaseLayout from '../layouts/BaseLayout.vue';
 
 const routes = [
   {
     path: '/',
-    name: 'Home',
-    component: () => import('../views/HomeView.vue')
-  },
-  {
-    path: '/schedule',
-    name: 'Schedule',
-    component: () => import('../views/ScheduleView.vue')
-  },
-  {
-    path: '/standings',
-    name: 'Standings',
-    component: () => import('../views/StandingsView.vue')
-  },
-  {
-    path: '/teams',
-    name: 'Teams',
-    component: () => import('../views/TeamsView.vue')
-  },
-  {
-    path: '/team/:mlbam_team_id',
-    name: 'Team',
-    component: () => import('../views/TeamView.vue'),
-    props: route => ({ mlbam_team_id: route.params.mlbam_team_id, name: route.query.name })
-  },
-  {
-    path: '/game/:game_pk',
-    name: 'Game',
-    component: () => import('../views/GameView.vue'),
-    props: route => ({ game_pk: route.params.game_pk })
-  },
-  {
-    path: '/players',
-    name: 'Players',
-    component: () => import('../views/PlayersView.vue')
-  },
-  {
-    path: '/leaders',
-    name: 'Leaders',
-    component: () => import('../views/LeadersView.vue')
-  },
-  {
-    path: '/player/:id',
-    name: 'Player',
-    component: () => import('../views/PlayerView.vue'),
-    props: route => ({ id: route.params.id, name: route.query.name })
-  },
-  {
-    path: '/developer',
-    name: 'ApiExplorer',
-    component: () => import('../views/ApiExplorerView.vue')
+    component: BaseLayout,
+    children: [
+      {
+        path: '',
+        name: 'Home',
+        component: () => import('../views/HomeView.vue')
+      },
+      {
+        path: 'schedule',
+        name: 'Schedule',
+        component: () => import('../views/ScheduleView.vue')
+      },
+      {
+        path: 'standings',
+        name: 'Standings',
+        component: () => import('../views/StandingsView.vue')
+      },
+      {
+        path: 'teams',
+        name: 'Teams',
+        component: () => import('../views/TeamsView.vue')
+      },
+      {
+        path: 'team/:mlbam_team_id',
+        name: 'Team',
+        component: () => import('../views/TeamView.vue'),
+        props: route => ({ mlbam_team_id: route.params.mlbam_team_id, name: route.query.name })
+      },
+      {
+        path: 'game/:game_pk',
+        name: 'Game',
+        component: () => import('../views/GameView.vue'),
+        props: route => ({ game_pk: route.params.game_pk })
+      },
+      {
+        path: 'players',
+        name: 'Players',
+        component: () => import('../views/PlayersView.vue')
+      },
+      {
+        path: 'leaders',
+        name: 'Leaders',
+        component: () => import('../views/LeadersView.vue')
+      },
+      {
+        path: 'player/:id',
+        name: 'Player',
+        component: () => import('../views/PlayerView.vue'),
+        props: route => ({ id: route.params.id, name: route.query.name })
+      },
+      {
+        path: 'developer',
+        name: 'ApiExplorer',
+        component: () => import('../views/ApiExplorerView.vue')
+      }
+    ]
   }
 ];
 


### PR DESCRIPTION
## Summary
- add BaseLayout wrapper component for consistent page width
- register layout in router so all routes render inside BaseLayout
- define `.page-wrapper` global styles

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b637a38b1483268d4efd866d88c749