### PR TITLE
refactor: move navigation into layout

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,23 +1,16 @@
 <template>
-  <div>
-    <nav class="top-nav">
-      <RouterLink to="/">Home</RouterLink>
-      <RouterLink to="/schedule">Schedule</RouterLink>
-      <RouterLink to="/standings">Standings</RouterLink>
-      <RouterLink to="/teams">Teams</RouterLink>
-      <RouterLink to="/players">Players</RouterLink>
-      <RouterLink to="/leaders">Leaders</RouterLink>
-      <RouterLink to="/developer" class="developer-link">Developer</RouterLink>
-    </nav>
+  <BaseLayout>
     <router-view />
-  </div>
+  </BaseLayout>
 </template>
 
 <script>
+import BaseLayout from './layouts/BaseLayout.vue';
 
 export default {
   name: 'App',
   components: {
+    BaseLayout
   }
 };
 </script>

--- a/frontend/src/layouts/BaseLayout.vue
+++ b/frontend/src/layouts/BaseLayout.vue
@@ -1,6 +1,17 @@
 <template>
-  <div class="page-wrapper">
-    <router-view />
+  <div>
+    <nav class="top-nav">
+      <RouterLink to="/">Home</RouterLink>
+      <RouterLink to="/schedule">Schedule</RouterLink>
+      <RouterLink to="/standings">Standings</RouterLink>
+      <RouterLink to="/teams">Teams</RouterLink>
+      <RouterLink to="/players">Players</RouterLink>
+      <RouterLink to="/leaders">Leaders</RouterLink>
+      <RouterLink to="/developer" class="developer-link">Developer</RouterLink>
+    </nav>
+    <div class="page-wrapper">
+      <slot />
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION
## Summary
- move top navigation menu from `App.vue` into `BaseLayout.vue`
- expose `<slot />` in `BaseLayout` for view content
- wrap router views with `BaseLayout` in `App.vue`

## Testing
- `npm test`
- `pytest` *(fails: process killed)*

------
https://chatgpt.com/codex/tasks/task_e_68b638fcca988326bc833250f7006cf7