### PR TITLE
Fix router layout duplication

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,65 +1,58 @@
 import { createRouter, createWebHistory } from 'vue-router';
-import BaseLayout from '../layouts/BaseLayout.vue';
 
 const routes = [
   {
     path: '/',
-    component: BaseLayout,
-    children: [
-      {
-        path: '',
-        name: 'Home',
-        component: () => import('../views/HomeView.vue')
-      },
-      {
-        path: 'schedule',
-        name: 'Schedule',
-        component: () => import('../views/ScheduleView.vue')
-      },
-      {
-        path: 'standings',
-        name: 'Standings',
-        component: () => import('../views/StandingsView.vue')
-      },
-      {
-        path: 'teams',
-        name: 'Teams',
-        component: () => import('../views/TeamsView.vue')
-      },
-      {
-        path: 'team/:mlbam_team_id',
-        name: 'Team',
-        component: () => import('../views/TeamView.vue'),
-        props: route => ({ mlbam_team_id: route.params.mlbam_team_id, name: route.query.name })
-      },
-      {
-        path: 'game/:game_pk',
-        name: 'Game',
-        component: () => import('../views/GameView.vue'),
-        props: route => ({ game_pk: route.params.game_pk })
-      },
-      {
-        path: 'players',
-        name: 'Players',
-        component: () => import('../views/PlayersView.vue')
-      },
-      {
-        path: 'leaders',
-        name: 'Leaders',
-        component: () => import('../views/LeadersView.vue')
-      },
-      {
-        path: 'player/:id',
-        name: 'Player',
-        component: () => import('../views/PlayerView.vue'),
-        props: route => ({ id: route.params.id, name: route.query.name })
-      },
-      {
-        path: 'developer',
-        name: 'ApiExplorer',
-        component: () => import('../views/ApiExplorerView.vue')
-      }
-    ]
+    name: 'Home',
+    component: () => import('../views/HomeView.vue')
+  },
+  {
+    path: '/schedule',
+    name: 'Schedule',
+    component: () => import('../views/ScheduleView.vue')
+  },
+  {
+    path: '/standings',
+    name: 'Standings',
+    component: () => import('../views/StandingsView.vue')
+  },
+  {
+    path: '/teams',
+    name: 'Teams',
+    component: () => import('../views/TeamsView.vue')
+  },
+  {
+    path: '/team/:mlbam_team_id',
+    name: 'Team',
+    component: () => import('../views/TeamView.vue'),
+    props: route => ({ mlbam_team_id: route.params.mlbam_team_id, name: route.query.name })
+  },
+  {
+    path: '/game/:game_pk',
+    name: 'Game',
+    component: () => import('../views/GameView.vue'),
+    props: route => ({ game_pk: route.params.game_pk })
+  },
+  {
+    path: '/players',
+    name: 'Players',
+    component: () => import('../views/PlayersView.vue')
+  },
+  {
+    path: '/leaders',
+    name: 'Leaders',
+    component: () => import('../views/LeadersView.vue')
+  },
+  {
+    path: '/player/:id',
+    name: 'Player',
+    component: () => import('../views/PlayerView.vue'),
+    props: route => ({ id: route.params.id, name: route.query.name })
+  },
+  {
+    path: '/developer',
+    name: 'ApiExplorer',
+    component: () => import('../views/ApiExplorerView.vue')
   }
 ];
 


### PR DESCRIPTION
## Summary
- remove nested BaseLayout route wrapper to prevent duplicated nav and allow page content to render
- define top-level routes directly for all views

## Testing
- `npm test`
- `pytest` *(fails: django.core.exceptions.ImproperlyConfigured: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68b63b2d47e08326af215e39e3976bf0