### PR TITLE
Ensure consistent width for leaders tables

### DIFF
--- a/frontend/src/views/LeadersView.vue
+++ b/frontend/src/views/LeadersView.vue
@@ -210,7 +210,14 @@ function onFieldingSort(e) {
 }
 
 .leaders-content {
+  width: 100%;
   max-width: 1100px;
+}
+
+.batting-leaders-table,
+.pitching-leaders-table,
+.fielding-leaders-table {
+  width: 100%;
 }
 
 .leaders-lists {


### PR DESCRIPTION
## Summary
- Set leaders page content area to full width with a max width constraint
- Force all leaders DataTables to span full width so tabs don't resize

## Testing
- `npm test`
- `pytest` *(fails: django.core.exceptions.ImproperlyConfigured: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68b64c5886508326aed8314d78d6dc58