### PR TITLE
Add player splits endpoint and frontend display

### DIFF
--- a/backend/apps/api/urls.py
+++ b/backend/apps/api/urls.py
@@ -11,6 +11,7 @@ from .views.players import (
     player_search,
     player_info,
     player_stats,
+    player_splits,
     player_headshot,
     league_leaders,
 )
@@ -36,6 +37,7 @@ urlpatterns = [
     path('players/', player_search, name='api-player-search'),
     path('players/<int:player_id>/', player_info, name='api-player-info'),
     path('players/<int:player_id>/stats/', player_stats, name='api-player-stats'),
+    path('players/<int:player_id>/splits/', player_splits, name='api-player-splits'),
     path('player/<int:player_id>/headshot/', player_headshot, name='api-player-headshot'),
     path('teams/', team_search, name='api-team-search'),
     path('teams/<int:mlbam_team_id>/', team_info, name='api-team-info'),

--- a/frontend/src/components/PlayerSplits.vue
+++ b/frontend/src/components/PlayerSplits.vue
@@ -1,0 +1,77 @@
+<template>
+  <div class="player-splits" v-if="data">
+    <div v-if="batting.length">
+      <h2>Batting Splits</h2>
+      <table class="stats-table">
+        <thead>
+          <tr>
+            <th>Split</th>
+            <th v-for="field in battingFields" :key="'bat-'+field">{{ fieldLabels[field] ?? field }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="row in batting" :key="row.split">
+            <td>{{ row.split }}</td>
+            <td v-for="field in battingFields" :key="field">{{ row[field] ?? '-' }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div v-if="pitching.length">
+      <h2>Pitching Splits</h2>
+      <table class="stats-table">
+        <thead>
+          <tr>
+            <th>Split</th>
+            <th v-for="field in pitchingFields" :key="'pit-'+field">{{ fieldLabels[field] ?? field }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="row in pitching" :key="row.split">
+            <td>{{ row.split }}</td>
+            <td v-for="field in pitchingFields" :key="field">{{ row[field] ?? '-' }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, computed } from 'vue';
+import { fetchPlayerSplits } from '../services/api.js';
+import { fieldLabels } from '../config/playerStatsConfig.js';
+
+const { id } = defineProps({ id: String });
+
+const data = ref(null);
+
+onMounted(async () => {
+  data.value = await fetchPlayerSplits(id);
+});
+
+const batting = computed(() => data.value?.batting || []);
+const pitching = computed(() => data.value?.pitching || []);
+
+const battingFields = ['gamesPlayed', 'atBats', 'hits', 'doubles', 'triples', 'homeRuns', 'rbi', 'avg', 'obp', 'slg', 'ops'];
+const pitchingFields = ['gamesPlayed', 'gamesPitched', 'inningsPitched', 'strikeOuts', 'baseOnBalls', 'hits', 'homeRuns', 'avg', 'obp', 'slg', 'ops', 'whip'];
+</script>
+
+<style scoped>
+.player-splits {
+  margin-top: 2rem;
+}
+.stats-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 2rem;
+}
+.stats-table th,
+.stats-table td {
+  border: 1px solid #ddd;
+  padding: 0.5rem;
+}
+.stats-table th {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+</style>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -46,6 +46,9 @@ export const fetchPlayer = (id, opts) =>
 export const fetchPlayerStats = (id, opts) =>
   apiFetch(`/api/players/${id}/stats/`, { cacheKey: `playerStats:${id}`, ...opts });
 
+export const fetchPlayerSplits = (id, opts) =>
+  apiFetch(`/api/players/${id}/splits/`, { cacheKey: `playerSplits:${id}`, ...opts });
+
 export const fetchTeamRecentSchedule = (id, opts) =>
   apiFetch(`/api/teams/${id}/recent_schedule/`, {
     cacheKey: `teamRecentSchedule:${id}`,
@@ -127,5 +130,6 @@ export default {
   fetchBattingLeaders,
   fetchPitchingLeaders,
   fetchFieldingLeaders,
+  fetchPlayerSplits,
 };
 

--- a/frontend/src/views/PlayerView.vue
+++ b/frontend/src/views/PlayerView.vue
@@ -66,7 +66,7 @@
           <PlayerStats :id="id" />
         </TabPanel>
         <TabPanel header="Splits">
-          <p>Splits coming soon.</p>
+          <PlayerSplits :id="id" />
         </TabPanel>
         <TabPanel header="Game Log">
           <p>Game Log coming soon.</p>
@@ -82,6 +82,7 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue';
 import PlayerStats from '../components/PlayerStats.vue';
+import PlayerSplits from '../components/PlayerSplits.vue';
 import TabView from 'primevue/tabview';
 import TabPanel from 'primevue/tabpanel';
 import teamColors from '../data/teamColors.json';


### PR DESCRIPTION
## Summary
- add `/api/players/<id>/splits/` endpoint using UnifiedDataClient
- expose player splits in PlayerView via new PlayerSplits component
- add service helper and tests for splits retrieval

## Testing
- `pytest` *(fails: backend/apps/api/tests/test_games.py, backend/apps/api/tests/test_leaders.py, backend/apps/api/tests/test_players.py::PlayerStatsApiTests::test_player_stats_endpoint, backend/apps/api/tests/test_players.py::PlayerSplitsApiTests::test_player_splits_endpoint, backend/apps/api/tests/test_teams.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b66a256f448326b0139ae4d2d10cbb