### PR TITLE
feat: add separators for player split groups

### DIFF
--- a/frontend/src/components/PlayerSplits.vue
+++ b/frontend/src/components/PlayerSplits.vue
@@ -10,12 +10,18 @@
           </tr>
         </thead>
         <tbody>
-          <tr v-for="split in battingSplitTypes" :key="split">
-            <td>{{ splitTypeLabels[split] }}</td>
-            <td v-for="field in standardHittingFields" :key="field">
-              {{ battingRowsBySplit[split]?.stat?.[field] ?? '-' }}
-            </td>
-          </tr>
+          <template v-for="(group, groupIndex) in splitTypeGroups" :key="groupIndex">
+            <tr
+              v-for="split in group"
+              :key="split"
+              :class="{ 'group-separator': groupIndex > 0 && split === group[0] }"
+            >
+              <td>{{ splitTypeLabels[split] }}</td>
+              <td v-for="field in standardHittingFields" :key="field">
+                {{ battingRowsBySplit[split]?.stat?.[field] ?? '-' }}
+              </td>
+            </tr>
+          </template>
         </tbody>
       </table>
     </div>
@@ -29,12 +35,18 @@
           </tr>
         </thead>
         <tbody>
-          <tr v-for="split in pitchingSplitTypes" :key="split">
-            <td>{{ splitTypeLabels[split] }}</td>
-            <td v-for="field in standardPitchingFields" :key="field">
-              {{ pitchingRowsBySplit[split]?.stat?.[field] ?? '-' }}
-            </td>
-          </tr>
+          <template v-for="(group, groupIndex) in splitTypeGroups" :key="groupIndex">
+            <tr
+              v-for="split in group"
+              :key="split"
+              :class="{ 'group-separator': groupIndex > 0 && split === group[0] }"
+            >
+              <td>{{ splitTypeLabels[split] }}</td>
+              <td v-for="field in standardPitchingFields" :key="field">
+                {{ pitchingRowsBySplit[split]?.stat?.[field] ?? '-' }}
+              </td>
+            </tr>
+          </template>
         </tbody>
       </table>
     </div>
@@ -51,8 +63,7 @@ import {
   advancedPitchingFields,
   fieldLabels,
   splitTypeLabels,
-  battingSplitTypes,
-  pitchingSplitTypes
+  splitTypeGroups
 } from '../config/playerStatsConfig.js';
 
 const { id } = defineProps({ id: String });
@@ -103,5 +114,9 @@ const pitchingRowsBySplit = computed(() => {
 }
 .stats-table th {
   background-color: rgba(255, 255, 255, 0.1);
+}
+
+.group-separator td {
+  border-top: 2px solid #aaa;
 }
 </style>

--- a/frontend/src/config/playerStatsConfig.js
+++ b/frontend/src/config/playerStatsConfig.js
@@ -15,9 +15,22 @@ export const advancedPitchingFields = ['team','qualityStarts','gamesFinished', '
   'wildPitches','balks','stolenBases','caughtStealing','pickoffs','strikePercentage',
   'pitchesPerInning','pitchesPerPlateAppearance'];
 
-export const battingSplitTypes = ['h', 'a', 'vl', 'vr','d','n','preas','posas','val','vnl','r0','r123','ron','ac','bc'];
+// Groups of related split codes used to display logical sections in the
+// splits tables. Adding a new group here will automatically provide visual
+// separation in the PlayerSplits component.
+export const splitTypeGroups = [
+  ['h', 'a'],          // Home/Away
+  ['vl', 'vr'],        // vs. L / vs. R
+  ['d', 'n'],          // Day/Night
+  ['preas', 'posas'],  // Pre/Post All-Star
+  ['val', 'vnl'],      // vs. AL / vs. NL
+  ['r0', 'r123', 'ron'], // Base state
+  ['ac', 'bc']         // Count leverage
+];
 
-export const pitchingSplitTypes = ['h', 'a', 'vl', 'vr', 'd', 'n', 'preas', 'posas','val','vnl','r0','r123','ron','ac','bc'];
+export const battingSplitTypes = splitTypeGroups.flat();
+
+export const pitchingSplitTypes = splitTypeGroups.flat();
 
 export const splitTypeLabels = {
   h: 'Home',


### PR DESCRIPTION
## Summary
- group split codes into logical sections
- visually separate groups in player splits tables

## Testing
- `npm test --prefix frontend`
- `pytest` *(fails: Internal Server Error... etc)*

------
https://chatgpt.com/codex/tasks/task_e_68b7114c2cec83268d1887bf51e35a8b