### PR TITLE
Align splits table header styling with player stats

### DIFF
--- a/frontend/src/components/PlayerSplits.vue
+++ b/frontend/src/components/PlayerSplits.vue
@@ -109,11 +109,13 @@ const pitchingRowsBySplit = computed(() => {
 }
 .stats-table th,
 .stats-table td {
-  border: 1px solid #ddd;
   padding: 0.5rem;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  text-align: center;
 }
 .stats-table th {
-  background-color: rgba(255, 255, 255, 0.1);
+  background: var(--color-primary);
+  color: #fff;
 }
 
 .group-separator td {


### PR DESCRIPTION
## Summary
- match splits table header styling to player stats headers

## Testing
- `npm test`
- `pytest` *(fails: tests did not complete; process killed)*

------
https://chatgpt.com/codex/tasks/task_e_68b71281d834832697802801994ed9ba