### PR TITLE
Register API models with Django admin

### DIFF
--- a/backend/apps/api/admin.py
+++ b/backend/apps/api/admin.py
@@ -1,0 +1,7 @@
+from django.contrib import admin
+
+from .models import PlayerIdInfo, TeamIdInfo, Venue
+
+admin.site.register(PlayerIdInfo)
+admin.site.register(TeamIdInfo)
+admin.site.register(Venue)


### PR DESCRIPTION
## Summary
- register PlayerIdInfo, TeamIdInfo, and Venue models with the Django admin site

## Testing
- `pytest` *(fails: tests not passing)*
- `python backend/manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68b712d875d08326bf870a5407b3a242