### PR TITLE
Show player, team, and venue columns in admin

### DIFF
--- a/backend/apps/api/admin.py
+++ b/backend/apps/api/admin.py
@@ -1,0 +1,58 @@
+from django.contrib import admin
+
+from .models import PlayerIdInfo, TeamIdInfo, Venue
+
+
+@admin.register(PlayerIdInfo)
+class PlayerIdInfoAdmin(admin.ModelAdmin):
+    """Admin configuration for PlayerIdInfo."""
+
+    list_display = (
+        "key_person",
+        "key_uuid",
+        "key_mlbam",
+        "key_retro",
+        "key_bbref",
+        "key_bbref_minors",
+        "key_fangraphs",
+        "key_npb",
+        "name_last",
+        "name_first",
+        "name_given",
+        "name_suffix",
+        "name_full",
+    )
+
+
+@admin.register(TeamIdInfo)
+class TeamIdInfoAdmin(admin.ModelAdmin):
+    """Admin configuration for TeamIdInfo."""
+
+    list_display = (
+        "mlbam_team_id",
+        "abbrev",
+        "full_name",
+        "location_name",
+        "team_name",
+        "league",
+        "fg_team_id",
+        "mlbam_league_id",
+        "mlbam_division_id",
+        "bref_team_id",
+        "retrosheet_team_id",
+        "active_from",
+        "active_to",
+    )
+
+
+@admin.register(Venue)
+class VenueAdmin(admin.ModelAdmin):
+    """Admin configuration for Venue."""
+
+    list_display = (
+        "mlbam_id",
+        "name",
+        "link",
+        "active",
+        "season",
+    )

--- a/backend/apps/api/models.py
+++ b/backend/apps/api/models.py
@@ -27,6 +27,10 @@ class PlayerIdInfo(models.Model):
     class Meta:
         db_table = 'player_id_infos'
 
+    def __str__(self) -> str:  # pragma: no cover - simple convenience method
+        """Return the player's full name for admin displays."""
+        return self.name_full or ""
+
 
 class TeamIdInfo(models.Model):
     mlbam_team_id = models.IntegerField(null=True)
@@ -46,6 +50,10 @@ class TeamIdInfo(models.Model):
     class Meta:
         db_table = 'team_id_infos'
 
+    def __str__(self) -> str:  # pragma: no cover - simple convenience method
+        """Return the team's full name for admin displays."""
+        return self.full_name or ""
+
 
 class Venue(models.Model):
     mlbam_id = models.IntegerField(null=True)
@@ -56,3 +64,7 @@ class Venue(models.Model):
 
     class Meta:
         db_table = 'venues'
+
+    def __str__(self) -> str:  # pragma: no cover - simple convenience method
+        """Return the venue name for admin displays."""
+        return self.name or ""


### PR DESCRIPTION
## Summary
- expose PlayerIdInfo fields in Django admin with `PlayerIdInfoAdmin`
- show all TeamIdInfo and Venue fields in their respective admin tables
- add `__str__` helpers for clearer row labels

## Testing
- `python backend/manage.py check`
- `pytest` *(fails: tests killed after multiple failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b712d875d08326bf870a5407b3a242