### PR TITLE
Fix schedule page reload extra header

### DIFF
--- a/backend/apps/web/templates/web/schedule.html
+++ b/backend/apps/web/templates/web/schedule.html
@@ -2,7 +2,6 @@
 {% load static %}
 {% block title %}Schedule{% endblock %}
 {% block content %}
-<h1 style="font-family: proxima-nova, 'open Sans', Helvetica, Arial, sans-serif;">Schedule</h1>
 <div id="vue-app"></div>
 {% if DJANGO_USE_VITE_DEV %}
     <script type="module" src="http://localhost:5173/@vite/client"></script>


### PR DESCRIPTION
## Summary
- Remove hardcoded `<h1>` header from server-rendered schedule template so reloading the schedule page no longer shows an extra white header.

## Testing
- `pytest` *(fails: TypeError: can only concatenate str (not "NoneType") to str)*

------
https://chatgpt.com/codex/tasks/task_e_68b758dd1ab48326b8629be2d6134287