### PR TITLE
feat: add http client and env config

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@primevue/themes": "^4.3.7",
+        "axios": "^1.11.0",
         "chart.js": "^4.5.0",
         "pinia": "^3.0.3",
         "primeicons": "^7.0.0",
@@ -1282,6 +1283,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1325,6 +1343,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/chai": {
@@ -1391,6 +1422,18 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/confbox": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
@@ -1447,6 +1490,29 @@
         "node": ">=6"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -1459,12 +1525,57 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.9",
@@ -1575,6 +1686,42 @@
         "node": ">=8"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1590,6 +1737,52 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -1601,6 +1794,57 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/hookable": {
@@ -1706,6 +1950,36 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mitt": {
@@ -1914,6 +2188,12 @@
       "engines": {
         "node": ">=12.11.0"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/quansync": {
       "version": "0.2.11",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
   "type": "module",
   "dependencies": {
     "@primevue/themes": "^4.3.7",
+    "axios": "^1.11.0",
     "chart.js": "^4.5.0",
     "pinia": "^3.0.3",
     "primeicons": "^7.0.0",

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,71 +1,70 @@
+import httpClient from './httpClient';
+
 const cache = new Map();
 
 async function apiFetch(url, { cacheKey, useCache = true, asText = false } = {}) {
-  console.log('Fetching URL:', url);
   if (useCache && cacheKey && cache.has(cacheKey)) {
     return cache.get(cacheKey);
   }
   try {
-    console.log('Making network request to:', url);
-    const res = await fetch(url);
-    console.log('Fetched URL:', url);
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const data = asText ? await res.text() : await res.json();
+    const response = await httpClient.get(url, {
+      responseType: asText ? 'text' : 'json',
+    });
+    const data = response.data;
     if (useCache && cacheKey) {
       cache.set(cacheKey, data);
     }
     return data;
   } catch (e) {
-    console.error('API fetch failed for', url, e);
     return null;
   }
 }
 
 export const fetchTeamDetails = (id, opts) =>
-  apiFetch(`/api/teams/${id}/`, { cacheKey: `team:${id}`, ...opts });
+  apiFetch(`/teams/${id}/`, { cacheKey: `team:${id}`, ...opts });
 
 export const fetchTeamLogo = (id, opts) =>
-  apiFetch(`/api/teams/${id}/logo/`, {
+  apiFetch(`/teams/${id}/logo/`, {
     cacheKey: `teamLogo:${id}`,
     asText: true,
     ...opts,
   });
 
 export const fetchTeamRecord = (id, opts) =>
-  apiFetch(`/api/teams/${id}/record/`, { cacheKey: `teamRecord:${id}`, ...opts });
+  apiFetch(`/teams/${id}/record/`, { cacheKey: `teamRecord:${id}`, ...opts });
 
 export const fetchStandings = (opts) =>
-  apiFetch('/api/standings/', { cacheKey: 'standings', ...opts });
+  apiFetch('/standings/', { cacheKey: 'standings', ...opts });
 
 export const fetchSchedule = (date, opts) =>
-  apiFetch(`/api/schedule/?date=${date}`, { cacheKey: `schedule:${date}`, ...opts });
+  apiFetch(`/schedule/?date=${date}`, { cacheKey: `schedule:${date}`, ...opts });
 
 export const fetchTopStat = (opts) =>
-  apiFetch('/api/top-stat', { cacheKey: 'topStat', ...opts });
+  apiFetch('/top-stat', { cacheKey: 'topStat', ...opts });
 
 export const fetchPlayer = (id, opts) =>
-  apiFetch(`/api/players/${id}/`, { cacheKey: `player:${id}`, ...opts });
+  apiFetch(`/players/${id}/`, { cacheKey: `player:${id}`, ...opts });
 
 export const fetchPlayerStats = (id, opts) =>
-  apiFetch(`/api/players/${id}/stats/`, { cacheKey: `playerStats:${id}`, ...opts });
+  apiFetch(`/players/${id}/stats/`, { cacheKey: `playerStats:${id}`, ...opts });
 
 export const fetchPlayerSplits = (id, opts) =>
-  apiFetch(`/api/players/${id}/splits/`, { cacheKey: `playerSplits:${id}`, ...opts });
+  apiFetch(`/players/${id}/splits/`, { cacheKey: `playerSplits:${id}`, ...opts });
 
 export const fetchTeamRecentSchedule = (id, opts) =>
-  apiFetch(`/api/teams/${id}/recent_schedule/`, {
+  apiFetch(`/teams/${id}/recent_schedule/`, {
     cacheKey: `teamRecentSchedule:${id}`,
     ...opts,
   });
 
 export const fetchTeamRoster = (id, opts) =>
-  apiFetch(`/api/teams/${id}/roster/`, {
+  apiFetch(`/teams/${id}/roster/`, {
     cacheKey: `teamRoster:${id}`,
     ...opts,
   });
 
 export const fetchTeamLeaders = (id, opts) =>
-  apiFetch(`/api/teams/${id}/leaders/`, {
+  apiFetch(`/teams/${id}/leaders/`, {
     cacheKey: `teamLeaders:${id}`,
     ...opts,
   });
@@ -79,7 +78,7 @@ export const fetchBattingLeaders = (
   opts,
 ) =>
   apiFetch(
-    `/api/unified/get_leaderboard_data/?season=${season}&group=hitting&stat_type=${statType}&limit=${limit}&offset=${offset}&sort_order=${sortOrder}`,
+    `/unified/get_leaderboard_data/?season=${season}&group=hitting&stat_type=${statType}&limit=${limit}&offset=${offset}&sort_order=${sortOrder}`,
     {
       cacheKey: `battingLeaders:${season}:${statType}:${sortOrder}:${limit}:${offset}`,
       ...opts,
@@ -95,7 +94,7 @@ export const fetchPitchingLeaders = (
   opts,
 ) =>
   apiFetch(
-    `/api/unified/get_leaderboard_data/?season=${season}&group=pitching&stat_type=${statType}&limit=${limit}&offset=${offset}&sort_order=${sortOrder}`,
+    `/unified/get_leaderboard_data/?season=${season}&group=pitching&stat_type=${statType}&limit=${limit}&offset=${offset}&sort_order=${sortOrder}`,
     {
       cacheKey: `pitchingLeaders:${season}:${statType}:${sortOrder}:${limit}:${offset}`,
       ...opts,
@@ -111,7 +110,7 @@ export const fetchFieldingLeaders = (
   opts,
 ) =>
   apiFetch(
-    `/api/unified/get_leaderboard_data/?season=${season}&group=fielding&stat_type=${statType}&limit=${limit}&offset=${offset}&sort_order=${sortOrder}`,
+    `/unified/get_leaderboard_data/?season=${season}&group=fielding&stat_type=${statType}&limit=${limit}&offset=${offset}&sort_order=${sortOrder}`,
     {
       cacheKey: `fieldingLeaders:${season}:${statType}:${sortOrder}:${limit}:${offset}`,
       ...opts,
@@ -135,4 +134,3 @@ export default {
   fetchFieldingLeaders,
   fetchPlayerSplits,
 };
-

--- a/frontend/src/services/httpClient.js
+++ b/frontend/src/services/httpClient.js
@@ -1,0 +1,32 @@
+import axios from 'axios';
+
+const baseURL = import.meta.env.VITE_API_BASE_URL || '/api';
+
+const httpClient = axios.create({ baseURL });
+
+httpClient.interceptors.request.use(
+  (config) => {
+    console.log(`Request: ${config.method?.toUpperCase()} ${config.baseURL}${config.url}`);
+    return config;
+  },
+  (error) => {
+    console.error('Request error:', error);
+    return Promise.reject(error);
+  }
+);
+
+httpClient.interceptors.response.use(
+  (response) => {
+    console.log(`Response: ${response.status} ${response.config.url}`);
+    return response;
+  },
+  (error) => {
+    const message = error.response
+      ? `API Error: ${error.response.status} ${error.response.statusText}`
+      : error.message;
+    console.error(message);
+    return Promise.reject(new Error(message));
+  }
+);
+
+export default httpClient;

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,44 +1,47 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import { resolve } from 'path';
 import Components from 'unplugin-vue-components/vite'
 import { PrimeVueResolver } from 'unplugin-vue-components/resolvers'
 import AutoImport from 'unplugin-auto-import/vite'
 
-
-export default defineConfig({
-  plugins: [
-    vue(),
-    AutoImport({
-      imports: ['vue', 'vue-router', 'pinia'],
-      dts: 'src/auto-imports.d.ts'
-    }),
-    Components({
-      resolvers: [
-        PrimeVueResolver({
-          importStyle: false,     // we’re on PrimeVue 4 (preset handles styles)
-          directives: true        // auto-register directives like v-tooltip, v-ripple
-        })
-      ],
-      dts: 'src/components.d.ts'  // (TS projects) generate typings
-    }),
-  ],
-  define: {
-    // Avoid runtime ReferenceError by replacing process.env.NODE_ENV at build time
-    'process.env.NODE_ENV': JSON.stringify('production')
-  },
-  build: {
-    lib: {
-      entry: resolve(__dirname, 'src/main.js'),
-      name: 'App',
-      fileName: () => 'main.js',
-      formats: ['iife']
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  return {
+    plugins: [
+      vue(),
+      AutoImport({
+        imports: ['vue', 'vue-router', 'pinia'],
+        dts: 'src/auto-imports.d.ts'
+      }),
+      Components({
+        resolvers: [
+          PrimeVueResolver({
+            importStyle: false,     // we’re on PrimeVue 4 (preset handles styles)
+            directives: true        // auto-register directives like v-tooltip, v-ripple
+          })
+        ],
+        dts: 'src/components.d.ts'  // (TS projects) generate typings
+      }),
+    ],
+    define: {
+      // Avoid runtime ReferenceError by replacing process.env.NODE_ENV at build time
+      'process.env.NODE_ENV': JSON.stringify('production'),
+      'import.meta.env.VITE_API_BASE_URL': JSON.stringify(env.VITE_API_BASE_URL || '/api'),
     },
-    outDir: '../backend/static/frontend',
-    emptyOutDir: true,
-    rollupOptions: {
-      output: {
-        format: 'iife'
+    build: {
+      lib: {
+        entry: resolve(__dirname, 'src/main.js'),
+        name: 'App',
+        fileName: () => 'main.js',
+        formats: ['iife']
+      },
+      outDir: '../backend/static/frontend',
+      emptyOutDir: true,
+      rollupOptions: {
+        output: {
+          format: 'iife'
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- add axios-based http client with logging and error handling
- switch API service to shared http client and remove console logs
- expose API base URL via Vite config

## Testing
- `npm test`
- `pytest` *(fails: TypeError can only concatenate str (not "NoneType") to str)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a8bbf8f08326a00987ec13aded8d