### PR TITLE
Use dedicated deep equality helper

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@primevue/themes": "^4.3.7",
         "axios": "^1.11.0",
         "chart.js": "^4.5.0",
+        "fast-deep-equal": "^3.1.3",
         "pinia": "^3.0.3",
         "primeicons": "^7.0.0",
         "primevue": "^4.3.7",
@@ -1653,6 +1654,12 @@
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
       "integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
     "node_modules/fdir": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@primevue/themes": "^4.3.7",
     "axios": "^1.11.0",
     "chart.js": "^4.5.0",
+    "fast-deep-equal": "^3.1.3",
     "pinia": "^3.0.3",
     "primeicons": "^7.0.0",
     "primevue": "^4.3.7",

--- a/frontend/src/composables/useCachedFetch.js
+++ b/frontend/src/composables/useCachedFetch.js
@@ -1,4 +1,5 @@
 import { isRef } from 'vue';
+import deepEqual from '../utils/deepEqual.js';
 
 /**
  * Generic helper to fetch and cache data via a Pinia store.
@@ -18,7 +19,6 @@ export async function useCachedFetch({
   assign,
   force = false,
 }) {
-  const deepEqual = (a, b) => JSON.stringify(a) === JSON.stringify(b);
 
   const cached = getter();
   if (cached && !force) {

--- a/frontend/src/utils/deepEqual.js
+++ b/frontend/src/utils/deepEqual.js
@@ -1,0 +1,14 @@
+import equal from 'fast-deep-equal';
+
+/**
+ * Deeply compares two values for equality.
+ *
+ * @param {*} a - First value to compare.
+ * @param {*} b - Second value to compare.
+ * @returns {boolean} True if the values are deeply equal, otherwise false.
+ */
+export function deepEqual(a, b) {
+  return equal(a, b);
+}
+
+export default deepEqual;

--- a/frontend/src/utils/deepEqual.test.js
+++ b/frontend/src/utils/deepEqual.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import deepEqual from './deepEqual.js';
+
+describe('deepEqual', () => {
+  it('treats objects with different key orders as equal', () => {
+    const a = { foo: 1, bar: 2 };
+    const b = { bar: 2, foo: 1 };
+    expect(deepEqual(a, b)).toBe(true);
+  });
+
+  it('detects differences in values', () => {
+    const a = { foo: 1, bar: 2 };
+    const b = { bar: 2, foo: 2 };
+    expect(deepEqual(a, b)).toBe(false);
+  });
+});

--- a/frontend/src/views/TeamView.vue
+++ b/frontend/src/views/TeamView.vue
@@ -66,6 +66,7 @@ import TeamSchedule from '../components/team/TeamSchedule.vue';
 import teamColors from '../data/teamColors.json';
 import { useTeamsStore } from '../store/teams';
 import { useCachedFetch } from '../composables/useCachedFetch';
+import deepEqual from '../utils/deepEqual.js';
 import {
   fetchTeamLogo,
   fetchTeamRecord,
@@ -147,7 +148,9 @@ onMounted(() => {
 
 watch(
   () => mlbam_team_id,
-  (newId) => {
+  (newId, oldId) => {
+    if (deepEqual(newId, oldId)) return;
+
     teamLogoSrc.value = "";
     teamRecord.value = null;
     recentSchedule.value = null;


### PR DESCRIPTION
## Summary
- add `fast-deep-equal` based utility function
- use deep equality helper in cached fetch logic and TeamView watcher
- cover deepEqual with tests for key order invariance

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7b32799088326b55349ea62ea80ce