### PR TITLE
Use environment-aware logger instead of console

### DIFF
--- a/frontend/src/components/PlayerSplits.vue
+++ b/frontend/src/components/PlayerSplits.vue
@@ -56,6 +56,7 @@
 <script setup>
 import { ref, onMounted, computed } from 'vue';
 import { fetchPlayerSplits } from '../services/api.js';
+import logger from '../utils/logger';
 import {
   standardHittingFields,
   advancedHittingFields,
@@ -71,9 +72,9 @@ const { id } = defineProps({ id: String });
 const data = ref(null);
 
 onMounted(async () => {
-  console.log('Fetching player splits for ID:', id);
+  logger.info('Fetching player splits for ID:', id);
   data.value = await fetchPlayerSplits(id);
-  console.log('Fetched player splits:', data.value);
+  logger.info('Fetched player splits:', data.value);
 });
 const batting = computed(() => data.value?.batting || []);
 const pitching = computed(() => data.value?.pitching || []);

--- a/frontend/src/composables/useSchedule.js
+++ b/frontend/src/composables/useSchedule.js
@@ -13,6 +13,7 @@ import {
   fetchSchedule as apiFetchSchedule,
   DEFAULT_SCHEDULE_TTL,
 } from '../services/api';
+import logger from '../utils/logger';
 
 const REVALIDATE_INTERVAL = DEFAULT_SCHEDULE_TTL;
 
@@ -150,7 +151,9 @@ export function useSchedule() {
     const iso = date.toISOString().split('T')[0];
     try {
       await fetchSchedule(iso, { force: iso === today });
-    } catch {}
+    } catch (e) {
+      logger.error(e);
+    }
   }
 
   async function nextDay() {
@@ -159,7 +162,9 @@ export function useSchedule() {
     const iso = date.toISOString().split('T')[0];
     try {
       await fetchSchedule(iso, { force: iso === today });
-    } catch {}
+    } catch (e) {
+      logger.error(e);
+    }
   }
 
   watch(

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,4 +1,5 @@
 import httpClient from './httpClient';
+import logger from '../utils/logger';
 
 const cache = new Map();
 
@@ -39,6 +40,7 @@ async function apiFetch(
     }
     return data;
   } catch (e) {
+    logger.error(e);
     return null;
   }
 }
@@ -58,6 +60,7 @@ export async function fetchSchedule(
     scheduleCache.set(date, { data, timestamp: now });
     return data;
   } catch (e) {
+    logger.error(e);
     return null;
   }
 }

--- a/frontend/src/services/httpClient.js
+++ b/frontend/src/services/httpClient.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import logger from '../utils/logger';
 
 const baseURL = import.meta.env.VITE_API_BASE_URL || '/api';
 
@@ -6,27 +7,29 @@ const httpClient = axios.create({ baseURL });
 
 httpClient.interceptors.request.use(
   (config) => {
-    console.log(`Request: ${config.method?.toUpperCase()} ${config.baseURL}${config.url}`);
+    logger.info(
+      `Request: ${config.method?.toUpperCase()} ${config.baseURL}${config.url}`,
+    );
     return config;
   },
   (error) => {
-    console.error('Request error:', error);
+    logger.error('Request error:', error);
     return Promise.reject(error);
-  }
+  },
 );
 
 httpClient.interceptors.response.use(
   (response) => {
-    console.log(`Response: ${response.status} ${response.config.url}`);
+    logger.info(`Response: ${response.status} ${response.config.url}`);
     return response;
   },
   (error) => {
     const message = error.response
       ? `API Error: ${error.response.status} ${error.response.statusText}`
       : error.message;
-    console.error(message);
+    logger.error(message);
     return Promise.reject(new Error(message));
-  }
+  },
 );
 
 export default httpClient;

--- a/frontend/src/store/standings.js
+++ b/frontend/src/store/standings.js
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia';
 import { fetchStandings as apiFetchStandings } from '../services/api.js';
+import logger from '../utils/logger';
 
 const recordCache = new Map();
 let standingsPromise;
@@ -39,7 +40,7 @@ export const useStandingsStore = defineStore('standings', {
             this.standingsByLeague = grouped;
           })
           .catch((e) => {
-            console.error(e);
+            logger.error(e);
             standingsPromise = null;
           });
       }

--- a/frontend/src/utils/logger.js
+++ b/frontend/src/utils/logger.js
@@ -1,0 +1,11 @@
+const noop = () => {};
+
+const logger = import.meta.env.PROD
+  ? { info: noop, warn: noop, error: noop }
+  : {
+      info: (...args) => console.info(...args),
+      warn: (...args) => console.warn(...args),
+      error: (...args) => console.error(...args),
+    };
+
+export default logger;

--- a/frontend/src/views/LeadersView.vue
+++ b/frontend/src/views/LeadersView.vue
@@ -101,6 +101,7 @@ import {
   fetchPitchingLeaders,
   fetchFieldingLeaders,
 } from '../services/api';
+import logger from '../utils/logger';
 
 const leaders = ref(null);
 const battingLeaders = ref([]);
@@ -119,7 +120,7 @@ onMounted(async () => {
     //   const res = await fetch('/api/leaders/');
     //   leaders.value = await res.json();
     // } catch (e) {
-    //   console.error('Failed to fetch league leaders:', e);
+    //   logger.error('Failed to fetch league leaders:', e);
     //   leaders.value = null;
     // }
     await Promise.all([
@@ -128,7 +129,7 @@ onMounted(async () => {
       loadFieldingLeaders(),
     ]);
   } catch (e) {
-    console.error('Failed to load leaders data:', e);
+    logger.error('Failed to load leaders data:', e);
   } finally {
     loading.value = false;
   }

--- a/frontend/src/views/PlayersView.vue
+++ b/frontend/src/views/PlayersView.vue
@@ -53,6 +53,7 @@
 import SearchAutocomplete from '../components/SearchAutocomplete.vue';
 import PlayerQuickList from '../components/PlayerQuickList.vue';
 import { onMounted, ref } from 'vue';
+import logger from '../utils/logger';
 
 const leaders = ref(null);
 
@@ -61,7 +62,7 @@ onMounted(async () => {
     const res = await fetch('/api/leaders/');
     leaders.value = await res.json();
   } catch (e) {
-    console.error('Failed to fetch league leaders:', e);
+    logger.error('Failed to fetch league leaders:', e);
     leaders.value = null;
   }
 });


### PR DESCRIPTION
## Summary
- add a logger utility that proxies console in development and no-ops in production
- replace direct console usage with logger across services, composables, and views

## Testing
- `pytest` *(fails: TypeError: can only concatenate str (not "NoneType") to str)*
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7b5c90cb48326ae9366b78f182108