### PR TITLE
Add player game log endpoint and frontend display

### DIFF
--- a/backend/apps/api/tests/test_players.py
+++ b/backend/apps/api/tests/test_players.py
@@ -142,6 +142,26 @@ class PlayerSplitsApiTests(TestCase):
         self.assertEqual(data['pitching'][1]['split'], 'vr')
 
 
+class PlayerGameLogApiTests(TestCase):
+    @patch('apps.api.views.UnifiedDataClient')
+    def test_player_gamelog_endpoint(self, mock_client_cls):
+        mock_client = mock_client_cls.return_value
+        mock_client.get_player_gamelog.return_value = {'stats': []}
+
+        PlayerIdInfo.objects.create(
+            id=1,
+            key_mlbam='123',
+            name_first='Test',
+            name_last='Player',
+        )
+
+        client = Client()
+        response = client.get('/api/players/1/gamelog/?stat_type=hitting&season=2025')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {'stats': []})
+        mock_client.get_player_gamelog.assert_called_once_with(123, 'hitting', 2025)
+
+
 class PlayerSearchApiTests(TestCase):
     def setUp(self):
         for i in range(11):

--- a/backend/apps/api/urls.py
+++ b/backend/apps/api/urls.py
@@ -12,6 +12,7 @@ from .views.players import (
     player_info,
     player_stats,
     player_splits,
+    player_gamelog,
     player_headshot,
     league_leaders,
 )
@@ -38,6 +39,7 @@ urlpatterns = [
     path('players/<int:player_id>/', player_info, name='api-player-info'),
     path('players/<int:player_id>/stats/', player_stats, name='api-player-stats'),
     path('players/<int:player_id>/splits/', player_splits, name='api-player-splits'),
+    path('players/<int:player_id>/gamelog/', player_gamelog, name='api-player-gamelog'),
     path('player/<int:player_id>/headshot/', player_headshot, name='api-player-headshot'),
     path('teams/', team_search, name='api-team-search'),
     path('teams/<int:mlbam_team_id>/', team_info, name='api-team-info'),

--- a/backend/apps/api/views/__init__.py
+++ b/backend/apps/api/views/__init__.py
@@ -17,6 +17,7 @@ from .players import (
     player_info,
     player_stats,
     league_leaders,
+    player_gamelog,
 )
 from .teams import (
     team_search,
@@ -49,6 +50,7 @@ __all__ = [
     'player_headshot',
     'player_info',
     'player_stats',
+    'player_gamelog',
     'league_leaders',
     'team_search',
     'team_info',

--- a/frontend/src/components.d.ts
+++ b/frontend/src/components.d.ts
@@ -16,6 +16,7 @@ declare module 'vue' {
     PlayerQuickList: typeof import('./components/PlayerQuickList.vue')['default']
     PlayerSplits: typeof import('./components/PlayerSplits.vue')['default']
     PlayerStats: typeof import('./components/PlayerStats.vue')['default']
+    PlayerGameLog: typeof import('./components/PlayerGameLog.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
     SearchAutocomplete: typeof import('./components/SearchAutocomplete.vue')['default']

--- a/frontend/src/components/PlayerGameLog.vue
+++ b/frontend/src/components/PlayerGameLog.vue
@@ -1,0 +1,78 @@
+<template>
+  <div v-if="rows.length">
+    <table class="stats-table">
+      <thead>
+        <tr>
+          <th>Date</th>
+          <th>Opp</th>
+          <th v-for="field in fields" :key="field">{{ fieldLabels[field] ?? field }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="row in rows" :key="row.date">
+          <td>{{ row.date }}</td>
+          <td>{{ row.opponent }}</td>
+          <td v-for="field in fields" :key="field">{{ row[field] ?? '-' }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <div v-else>
+    <p>No game log data available.</p>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, computed } from 'vue';
+import { fetchPlayerGameLog } from '../services/api.js';
+import { fieldLabels } from '../config/playerStatsConfig.js';
+
+const props = defineProps({
+  id: String,
+  statType: { type: String, default: 'hitting' },
+  season: { type: Number, default: new Date().getFullYear() },
+});
+
+const data = ref(null);
+
+onMounted(async () => {
+  data.value = await fetchPlayerGameLog(props.id, props.statType, props.season);
+});
+
+const fieldsByType = {
+  hitting: ['atBats', 'runs', 'hits', 'homeRuns', 'rbi', 'baseOnBalls', 'strikeOuts', 'avg'],
+  pitching: ['inningsPitched', 'runs', 'earnedRuns', 'hits', 'homeRuns', 'baseOnBalls', 'strikeOuts', 'era'],
+};
+
+const fields = computed(() => fieldsByType[props.statType] || []);
+
+const rows = computed(() => {
+  const splits = data.value?.stats?.[0]?.splits || [];
+  return splits.map(s => {
+    const stat = s.stat || {};
+    const row = {
+      date: s.date,
+      opponent: s.opponent?.abbreviation,
+    };
+    fields.value.forEach(f => {
+      row[f] = stat[f];
+    });
+    return row;
+  });
+});
+</script>
+
+<style scoped>
+.stats-table {
+  margin-top: 1rem;
+  border-collapse: collapse;
+}
+.stats-table th,
+.stats-table td {
+  border: 1px solid #ddd;
+  padding: 0.5rem;
+}
+.stats-table th {
+  background-color: #f5f5f5;
+}
+</style>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -93,6 +93,12 @@ export const fetchPlayerStats = (id, opts) =>
 export const fetchPlayerSplits = (id, opts) =>
   apiFetch(`/players/${id}/splits/`, { cacheKey: `playerSplits:${id}`, ...opts });
 
+export const fetchPlayerGameLog = (id, statType, season, opts) =>
+  apiFetch(
+    `/players/${id}/gamelog/?stat_type=${statType}&season=${season}`,
+    { cacheKey: `playerGameLog:${id}:${statType}:${season}`, ...opts },
+  );
+
 export const fetchTeamRecentSchedule = (id, opts) =>
   apiFetch(`/teams/${id}/recent_schedule/`, {
     cacheKey: `teamRecentSchedule:${id}`,
@@ -175,4 +181,5 @@ export default {
   fetchPitchingLeaders,
   fetchFieldingLeaders,
   fetchPlayerSplits,
+  fetchPlayerGameLog,
 };

--- a/frontend/src/views/PlayerView.vue
+++ b/frontend/src/views/PlayerView.vue
@@ -63,7 +63,7 @@
           <PlayerSplits :id="id" />
         </TabPanel>
         <TabPanel header="Game Log">
-          <p>Game Log coming soon.</p>
+          <PlayerGameLog :id="id" :stat-type="statType" />
         </TabPanel>
         <TabPanel header="Charts & Trends">
           <p>Charts & Trends coming soon.</p>
@@ -91,6 +91,7 @@
 import { ref, computed, onMounted } from 'vue';
 import PlayerStats from '../components/PlayerStats.vue';
 import PlayerSplits from '../components/PlayerSplits.vue';
+import PlayerGameLog from '../components/PlayerGameLog.vue';
 import TabView from 'primevue/tabview';
 import TabPanel from 'primevue/tabpanel';
 import Dialog from 'primevue/dialog';
@@ -116,6 +117,8 @@ const weight = ref('');
 const batSide = ref('');
 const throwSide = ref('');
 const loading = ref(true);
+
+const statType = computed(() => (position.value === 'Pitcher' ? 'pitching' : 'hitting'));
 
 const teamColorStyle = computed(() => {
   const colors = teamColors[teamName.value] || [];


### PR DESCRIPTION
## Summary
- expose `/api/players/<id>/gamelog/` that uses `get_player_gamelog`
- add frontend service and `PlayerGameLog` component to render game logs
- integrate game logs into player page

## Testing
- `pytest` *(fails: TypeError: can only concatenate str (not "NoneType") to str)*
- `npm test` *(fails: Cannot find package 'fast-deep-equal')*


------
https://chatgpt.com/codex/tasks/task_e_68b7bc068998832690d9a537a98be93a