### PR TITLE
Fix Player Game Log stat type for pitchers

### DIFF
--- a/frontend/src/views/PlayerView.vue
+++ b/frontend/src/views/PlayerView.vue
@@ -63,7 +63,7 @@
           <PlayerSplits :id="id" />
         </TabPanel>
         <TabPanel header="Game Log">
-          <PlayerGameLog :id="id" :stat-type="statType" />
+          <PlayerGameLog v-if="position" :id="id" :stat-type="statType" />
         </TabPanel>
         <TabPanel header="Charts & Trends">
           <p>Charts & Trends coming soon.</p>


### PR DESCRIPTION
## Summary
- delay PlayerGameLog mount until player position is known so pitcher pages request pitching stats

## Testing
- `npm test`
- `pytest` *(fails: TypeError: can only concatenate str (not "NoneType") to str)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c6669e808326a42685953ec40030