### PR TITLE
feat: expose statcast data endpoints for players

### DIFF
--- a/backend/apps/api/tests/test_players.py
+++ b/backend/apps/api/tests/test_players.py
@@ -162,6 +162,54 @@ class PlayerGameLogApiTests(TestCase):
         mock_client.get_player_gamelog.assert_called_once_with(123, 'hitting', 2025)
 
 
+class PlayerStatcastBatterApiTests(TestCase):
+    @patch('apps.api.views.UnifiedDataClient')
+    def test_player_statcast_batter_endpoint(self, mock_client_cls):
+        mock_client = mock_client_cls.return_value
+        mock_client.fetch_statcast_batter_data.return_value = {'results': []}
+
+        PlayerIdInfo.objects.create(
+            id=1,
+            key_mlbam='123',
+            name_first='Test',
+            name_last='Player',
+        )
+
+        client = Client()
+        response = client.get(
+            '/api/players/1/statcast/batter/?start_date=2024-03-01&end_date=2024-04-01'
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {'results': []})
+        mock_client.fetch_statcast_batter_data.assert_called_once_with(
+            123, '2024-03-01', '2024-04-01'
+        )
+
+
+class PlayerStatcastPitcherApiTests(TestCase):
+    @patch('apps.api.views.UnifiedDataClient')
+    def test_player_statcast_pitcher_endpoint(self, mock_client_cls):
+        mock_client = mock_client_cls.return_value
+        mock_client.fetch_statcast_pitcher_data.return_value = {'results': []}
+
+        PlayerIdInfo.objects.create(
+            id=1,
+            key_mlbam='123',
+            name_first='Test',
+            name_last='Player',
+        )
+
+        client = Client()
+        response = client.get(
+            '/api/players/1/statcast/pitcher/?start_date=2024-03-01&end_date=2024-04-01'
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {'results': []})
+        mock_client.fetch_statcast_pitcher_data.assert_called_once_with(
+            123, '2024-03-01', '2024-04-01'
+        )
+
+
 class PlayerSearchApiTests(TestCase):
     def setUp(self):
         for i in range(11):

--- a/backend/apps/api/urls.py
+++ b/backend/apps/api/urls.py
@@ -15,6 +15,8 @@ from .views.players import (
     player_gamelog,
     player_headshot,
     league_leaders,
+    player_statcast_batter_data,
+    player_statcast_pitcher_data,
 )
 from .views.teams import (
     team_search,
@@ -40,6 +42,8 @@ urlpatterns = [
     path('players/<int:player_id>/stats/', player_stats, name='api-player-stats'),
     path('players/<int:player_id>/splits/', player_splits, name='api-player-splits'),
     path('players/<int:player_id>/gamelog/', player_gamelog, name='api-player-gamelog'),
+    path('players/<int:player_id>/statcast/batter/', player_statcast_batter_data, name='api-player-statcast-batter'),
+    path('players/<int:player_id>/statcast/pitcher/', player_statcast_pitcher_data, name='api-player-statcast-pitcher'),
     path('player/<int:player_id>/headshot/', player_headshot, name='api-player-headshot'),
     path('teams/', team_search, name='api-team-search'),
     path('teams/<int:mlbam_team_id>/', team_info, name='api-team-info'),

--- a/backend/apps/api/views/__init__.py
+++ b/backend/apps/api/views/__init__.py
@@ -18,6 +18,8 @@ from .players import (
     player_stats,
     league_leaders,
     player_gamelog,
+    player_statcast_batter_data,
+    player_statcast_pitcher_data,
 )
 from .teams import (
     team_search,
@@ -51,6 +53,8 @@ __all__ = [
     'player_info',
     'player_stats',
     'player_gamelog',
+    'player_statcast_batter_data',
+    'player_statcast_pitcher_data',
     'league_leaders',
     'team_search',
     'team_info',
@@ -76,6 +80,8 @@ def list_api_endpoints(request):
         'api-player-search': ['q'],
         'api-team-search': ['q'],
         'api-team-record': ['season'],
+        'api-player-statcast-batter': ['start_date', 'end_date'],
+        'api-player-statcast-pitcher': ['start_date', 'end_date'],
     }
 
     for pattern in api_urls.urlpatterns:

--- a/backend/apps/api/views/players.py
+++ b/backend/apps/api/views/players.py
@@ -1,3 +1,4 @@
+
 """Player-related API views."""
 
 from datetime import datetime
@@ -285,6 +286,92 @@ def player_gamelog(request, client, player_id: int):
     except Exception as exc:  # pragma: no cover - defensive
         logger.error(
             "Error fetching game log for player_id=%s, key_mlbam=%s: %s",
+            player_id,
+            key_mlbam,
+            exc,
+        )
+        return Response({'error': str(exc)}, status=500)
+
+
+@extend_schema(responses=OpenApiTypes.OBJECT)
+@api_view(['GET'])
+@require_unified_client
+def player_statcast_batter_data(request, client, player_id: int):
+    """Return Statcast data for a batter over a date range."""
+    start_date = request.GET.get('start_date')
+    end_date = request.GET.get('end_date')
+    if not start_date or not end_date:
+        return Response({'error': 'start_date and end_date are required'}, status=400)
+
+    key_mlbam = (
+        PlayerIdInfo.objects.filter(id=player_id)
+        .values_list("key_mlbam", flat=True)
+        .first()
+    )
+    if key_mlbam is None:
+        key_mlbam = (
+            PlayerIdInfo.objects.filter(key_mlbam=str(player_id))
+            .values_list("key_mlbam", flat=True)
+            .first()
+        )
+        if key_mlbam is None:
+            key_mlbam = str(player_id)
+
+    key_mlbam = str(key_mlbam)
+    if key_mlbam.endswith('.0'):
+        key_mlbam = key_mlbam[:-2]
+
+    try:
+        data = client.fetch_statcast_batter_data(
+            int(key_mlbam), start_date, end_date
+        )
+        return Response(data)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error(
+            "Error fetching Statcast batter data for player_id=%s, key_mlbam=%s: %s",
+            player_id,
+            key_mlbam,
+            exc,
+        )
+        return Response({'error': str(exc)}, status=500)
+
+
+@extend_schema(responses=OpenApiTypes.OBJECT)
+@api_view(['GET'])
+@require_unified_client
+def player_statcast_pitcher_data(request, client, player_id: int):
+    """Return Statcast data for a pitcher over a date range."""
+    start_date = request.GET.get('start_date')
+    end_date = request.GET.get('end_date')
+    if not start_date or not end_date:
+        return Response({'error': 'start_date and end_date are required'}, status=400)
+
+    key_mlbam = (
+        PlayerIdInfo.objects.filter(id=player_id)
+        .values_list("key_mlbam", flat=True)
+        .first()
+    )
+    if key_mlbam is None:
+        key_mlbam = (
+            PlayerIdInfo.objects.filter(key_mlbam=str(player_id))
+            .values_list("key_mlbam", flat=True)
+            .first()
+        )
+        if key_mlbam is None:
+            key_mlbam = str(player_id)
+
+    key_mlbam = str(key_mlbam)
+    if key_mlbam.endswith('.0'):
+        key_mlbam = key_mlbam[:-2]
+
+    try:
+        data = client.fetch_statcast_pitcher_data(
+            int(key_mlbam), start_date, end_date
+        )
+        return Response(data)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error(
+            "Error fetching Statcast pitcher data for player_id=%s, key_mlbam=%s: %s",
             player_id,
             key_mlbam,
             exc,


### PR DESCRIPTION
## Summary
- add API endpoints to expose `fetch_statcast_batter_data` and `fetch_statcast_pitcher_data`
- wire up routes and API explorer metadata
- add tests for the new statcast endpoints

## Testing
- `pytest` *(fails: can only concatenate str (not "NoneType") to str due to missing database configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b87c5f81d48326868657cb7c9e7e44