### PR TITLE
feat: dynamically load Vite dev scripts

### DIFF
--- a/backend/apps/web/templates/web/base.html
+++ b/backend/apps/web/templates/web/base.html
@@ -32,7 +32,28 @@
     {% block head %}{% endblock %}
 </head>
 <body>
-    
+
     {% block content %}{% endblock %}
+
+    {% if DJANGO_USE_VITE_DEV %}
+    <script>
+        (function () {
+            const protocol = window.location.protocol;
+            const host = window.location.hostname;
+            const base = `${protocol}//${host}:5173`;
+            [
+                `${base}/@vite/client`,
+                `${base}/src/main.js`,
+            ].forEach(src => {
+                const el = document.createElement('script');
+                el.type = 'module';
+                el.src = src;
+                document.head.appendChild(el);
+            });
+        })();
+    </script>
+    {% else %}
+    <script src="{% static 'frontend/main.js' %}"></script>
+    {% endif %}
 </body>
 </html>

--- a/backend/apps/web/templates/web/developer.html
+++ b/backend/apps/web/templates/web/developer.html
@@ -4,10 +4,4 @@
 {% block content %}
 <h1 style="font-family: proxima-nova, 'open Sans', Helvetica, Arial, sans-serif;">Developer</h1>
 <div id="vue-app"></div>
-{% if DJANGO_USE_VITE_DEV %}
-    <script type="module" src="http://localhost:5173/@vite/client"></script>
-    <script type="module" src="http://localhost:5173/src/main.js"></script>
-{% else %}
-    <script src="{% static 'frontend/main.js' %}"></script>
-{% endif %}
 {% endblock %}

--- a/backend/apps/web/templates/web/game.html
+++ b/backend/apps/web/templates/web/game.html
@@ -3,10 +3,4 @@
 {% block title %}Teams - Baseball Data Lab Web{% endblock %}
 {% block content %}
 <div id="vue-app"></div>
-{% if DJANGO_USE_VITE_DEV %}
-    <script type="module" src="http://localhost:5173/@vite/client"></script>
-    <script type="module" src="http://localhost:5173/src/main.js"></script>
-{% else %}
-    <script src="{% static 'frontend/main.js' %}"></script>
-{% endif %}
 {% endblock %}

--- a/backend/apps/web/templates/web/home.html
+++ b/backend/apps/web/templates/web/home.html
@@ -4,10 +4,4 @@
 {% block content %}
 <h1 style="font-family: proxima-nova, 'open Sans', Helvetica, Arial, sans-serif;"></h1>
 <div id="vue-app"></div>
-{% if DJANGO_USE_VITE_DEV %}
-    <script type="module" src="http://localhost:5173/@vite/client"></script>
-    <script type="module" src="http://localhost:5173/src/main.js"></script>
-{% else %}
-    <script src="{% static 'frontend/main.js' %}"></script>
-{% endif %}
 {% endblock %}

--- a/backend/apps/web/templates/web/index.html
+++ b/backend/apps/web/templates/web/index.html
@@ -6,13 +6,4 @@
 
 {{ schedule|json_script:"schedule-data" }}
 <div id="vue-app"></div>
-
-{% if DJANGO_USE_VITE_DEV %}
-    <!-- Vite dev server with HMR -->
-    <script type="module" src="http://localhost:5173/@vite/client"></script>
-    <script type="module" src="http://localhost:5173/src/main.js"></script>
-{% else %}
-    <!-- Built static bundle -->
-    <script src="{% static 'frontend/main.js' %}"></script>
-{% endif %}
 {% endblock %}

--- a/backend/apps/web/templates/web/leaders.html
+++ b/backend/apps/web/templates/web/leaders.html
@@ -3,10 +3,4 @@
 {% block title %}Baseball Data Lab Web{% endblock %}
 {% block content %}
 <div id="vue-app"></div>
-{% if DJANGO_USE_VITE_DEV %}
-    <script type="module" src="http://localhost:5173/@vite/client"></script>
-    <script type="module" src="http://localhost:5173/src/main.js"></script>
-{% else %}
-    <script src="{% static 'frontend/main.js' %}"></script>
-{% endif %}
 {% endblock %}

--- a/backend/apps/web/templates/web/new_game.html
+++ b/backend/apps/web/templates/web/new_game.html
@@ -3,10 +3,4 @@
 {% block title %}Teams - Baseball Data Lab Web{% endblock %}
 {% block content %}
 <div id="vue-app"></div>
-{% if DJANGO_USE_VITE_DEV %}
-    <script type="module" src="http://localhost:5173/@vite/client"></script>
-    <script type="module" src="http://localhost:5173/src/main.js"></script>
-{% else %}
-    <script src="{% static 'frontend/main.js' %}"></script>
-{% endif %}
 {% endblock %}

--- a/backend/apps/web/templates/web/player.html
+++ b/backend/apps/web/templates/web/player.html
@@ -3,10 +3,4 @@
 {% block title %}Baseball Data Lab Web{% endblock %}
 {% block content %}
 <div id="vue-app"></div>
-{% if DJANGO_USE_VITE_DEV %}
-    <script type="module" src="http://localhost:5173/@vite/client"></script>
-    <script type="module" src="http://localhost:5173/src/main.js"></script>
-{% else %}
-    <script src="{% static 'frontend/main.js' %}"></script>
-{% endif %}
 {% endblock %}

--- a/backend/apps/web/templates/web/players.html
+++ b/backend/apps/web/templates/web/players.html
@@ -3,10 +3,4 @@
 {% block title %}Baseball Data Lab Web{% endblock %}
 {% block content %}
 <div id="vue-app"></div>
-{% if DJANGO_USE_VITE_DEV %}
-    <script type="module" src="http://localhost:5173/@vite/client"></script>
-    <script type="module" src="http://localhost:5173/src/main.js"></script>
-{% else %}
-    <script src="{% static 'frontend/main.js' %}"></script>
-{% endif %}
 {% endblock %}

--- a/backend/apps/web/templates/web/schedule.html
+++ b/backend/apps/web/templates/web/schedule.html
@@ -3,10 +3,4 @@
 {% block title %}Schedule{% endblock %}
 {% block content %}
 <div id="vue-app"></div>
-{% if DJANGO_USE_VITE_DEV %}
-    <script type="module" src="http://localhost:5173/@vite/client"></script>
-    <script type="module" src="http://localhost:5173/src/main.js"></script>
-{% else %}
-    <script src="{% static 'frontend/main.js' %}"></script>
-{% endif %}
 {% endblock %}

--- a/backend/apps/web/templates/web/standings.html
+++ b/backend/apps/web/templates/web/standings.html
@@ -4,10 +4,4 @@
 {% block content %}
 <h1 style="font-family: proxima-nova, 'open Sans', Helvetica, Arial, sans-serif;">Standings</h1>
 <div id="vue-app"></div>
-{% if DJANGO_USE_VITE_DEV %}
-    <script type="module" src="http://localhost:5173/@vite/client"></script>
-    <script type="module" src="http://localhost:5173/src/main.js"></script>
-{% else %}
-    <script src="{% static 'frontend/main.js' %}"></script>
-{% endif %}
 {% endblock %}

--- a/backend/apps/web/templates/web/team.html
+++ b/backend/apps/web/templates/web/team.html
@@ -3,10 +3,4 @@
 {% block title %}Teams - Baseball Data Lab Web{% endblock %}
 {% block content %}
 <div id="vue-app"></div>
-{% if DJANGO_USE_VITE_DEV %}
-    <script type="module" src="http://localhost:5173/@vite/client"></script>
-    <script type="module" src="http://localhost:5173/src/main.js"></script>
-{% else %}
-    <script src="{% static 'frontend/main.js' %}"></script>
-{% endif %}
 {% endblock %}

--- a/backend/apps/web/templates/web/teams.html
+++ b/backend/apps/web/templates/web/teams.html
@@ -3,10 +3,4 @@
 {% block title %}Teams - Baseball Data Lab Web{% endblock %}
 {% block content %}
 <div id="vue-app"></div>
-{% if DJANGO_USE_VITE_DEV %}
-    <script type="module" src="http://localhost:5173/@vite/client"></script>
-    <script type="module" src="http://localhost:5173/src/main.js"></script>
-{% else %}
-    <script src="{% static 'frontend/main.js' %}"></script>
-{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- load Vite dev assets in the base template using `window.location` so dev clients on the LAN get the correct host
- remove duplicate script tags from individual templates

## Testing
- `pytest` (fails: can only concatenate str (not "NoneType") to str)
- `npm test --prefix frontend` (fails: LeadersView filtering > calls API with filters and updates table)


------
https://chatgpt.com/codex/tasks/task_e_68b896b3384c832689a738ef2a68b01d