### PR TITLE
Display player draft details on player overview

### DIFF
--- a/backend/apps/api/serializers.py
+++ b/backend/apps/api/serializers.py
@@ -11,6 +11,15 @@ class PlayerSearchResultSerializer(serializers.Serializer):
     key_mlbam = serializers.CharField(allow_null=True)
 
 
+class DraftInfoSerializer(serializers.Serializer):
+    year = serializers.IntegerField(allow_null=True)
+    round = serializers.CharField(allow_null=True)
+    pick = serializers.IntegerField(allow_null=True)
+    overall = serializers.IntegerField(allow_null=True)
+    team_id = serializers.IntegerField(allow_null=True)
+    team_name = serializers.CharField(allow_null=True)
+
+
 class PlayerInfoSerializer(serializers.Serializer):
     team_id = serializers.IntegerField(allow_null=True)
     team_name = serializers.CharField(allow_null=True)
@@ -22,6 +31,7 @@ class PlayerInfoSerializer(serializers.Serializer):
     weight = serializers.CharField(allow_null=True)
     bat_side = serializers.CharField(allow_null=True)
     throw_side = serializers.CharField(allow_null=True)
+    draft = DraftInfoSerializer(allow_null=True, required=False)
 
 
 class LeagueLeaderEntrySerializer(serializers.Serializer):

--- a/backend/apps/api/tests/test_players.py
+++ b/backend/apps/api/tests/test_players.py
@@ -55,6 +55,13 @@ class PlayerInfoApiTests(TestCase):
             'weight': 200,
             'batSide': {'description': 'Right'},
             'pitchHand': {'description': 'Left'},
+            'draft': {
+                'year': 2010,
+                'round': '1',
+                'pick': 5,
+                'overall': 5,
+                'team': {'id': 222, 'name': 'Draft Team'},
+            },
         }
 
         PlayerIdInfo.objects.create(
@@ -78,6 +85,17 @@ class PlayerInfoApiTests(TestCase):
         self.assertEqual(data['weight'], 200)
         self.assertEqual(data['bat_side'], 'Right')
         self.assertEqual(data['throw_side'], 'Left')
+        self.assertEqual(
+            data['draft'],
+            {
+                'year': 2010,
+                'round': '1',
+                'pick': 5,
+                'overall': 5,
+                'team_id': 222,
+                'team_name': 'Draft Team',
+            },
+        )
         mock_client.fetch_player_info.assert_called_once_with(123)
 
 

--- a/backend/apps/api/views/players.py
+++ b/backend/apps/api/views/players.py
@@ -139,6 +139,16 @@ def player_info(request, client, player_id: int):
         pos = info.get("primaryPosition", {}) or {}
         bat = info.get("batSide", {}) or {}
         throw = info.get("pitchHand", {}) or {}
+        draft = info.get("draft", {}) or {}
+        draft_team = draft.get("team", {}) or {}
+        draft_data = {
+            "year": draft.get("year"),
+            "round": draft.get("round"),
+            "pick": draft.get("pick"),
+            "overall": draft.get("overall"),
+            "team_id": draft_team.get("id"),
+            "team_name": draft_team.get("name"),
+        } if draft else None
         birth_city = info.get("birthCity")
         birth_state = info.get("birthStateProvince")
         birth_country = info.get("birthCountry")
@@ -160,6 +170,7 @@ def player_info(request, client, player_id: int):
             "weight": info.get("weight"),
             "bat_side": bat.get("description"),
             "throw_side": throw.get("description"),
+            "draft": draft_data,
         }
         return Response(data)
     except Exception as exc:  # pragma: no cover - defensive

--- a/frontend/src/views/PlayerView.vue
+++ b/frontend/src/views/PlayerView.vue
@@ -53,6 +53,9 @@
                 <strong>B/T:</strong>
                 {{ batSide || '?' }} / {{ throwSide || '?' }}
               </li>
+              <li v-if="formattedDraft">
+                <strong>Draft:</strong> {{ formattedDraft }}
+              </li>
             </ul>
           </section>
         </TabPanel>
@@ -116,6 +119,7 @@ const height = ref('');
 const weight = ref('');
 const batSide = ref('');
 const throwSide = ref('');
+const draft = ref(null);
 const loading = ref(true);
 
 const statType = computed(() => (position.value === 'Pitcher' ? 'pitching' : 'hitting'));
@@ -142,13 +146,27 @@ const formattedBirthDate = computed(() => {
   }
 });
 
+const formattedDraft = computed(() => {
+  const d = draft.value;
+  if (!d) return '';
+  const parts = [];
+  if (d.year) parts.push(d.year);
+  const roundPick = [];
+  if (d.round) roundPick.push(`Rd ${d.round}`);
+  if (d.pick) roundPick.push(`Pk ${d.pick}`);
+  if (roundPick.length) parts.push(roundPick.join(', '));
+  if (d.team_name) parts.push(d.team_name);
+  return parts.join(' - ');
+});
+
 const hasBio = computed(() =>
   birthDate.value ||
   birthPlace.value ||
   height.value ||
   weight.value ||
   batSide.value ||
-  throwSide.value
+  throwSide.value ||
+  formattedDraft.value
 );
 
 onMounted(async () => {
@@ -164,6 +182,7 @@ onMounted(async () => {
       weight.value = data.weight || '';
       batSide.value = data.bat_side || '';
       throwSide.value = data.throw_side || '';
+      draft.value = data.draft || null;
     }
   } finally {
     loading.value = false;


### PR DESCRIPTION
## Summary
- expose draft data from UnifiedDataClient in player_info API response
- serialize draft information and show on player overview tab
- test player info API for new draft data

## Testing
- `DJANGO_SETTINGS_MODULE=baseball_data_lab_web.settings.sqlite_test pytest backend/apps/api/tests/test_players.py::PlayerInfoApiTests::test_player_info_endpoint -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8c1436b988326934f84a0038d41f0