### PR TITLE
refactor: consolidate leader fetching

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -117,7 +117,8 @@ export const fetchTeamLeaders = (id, opts) =>
     ...opts,
   });
 
-export const fetchBattingLeaders = (
+export const fetchLeaders = ({
+  group,
   season,
   league_ids,
   team_id,
@@ -125,19 +126,17 @@ export const fetchBattingLeaders = (
   sortOrder = 'desc',
   limit = 10,
   offset = 0,
-  {
-    ...opts
-  } = {},
-) => {
+  ...opts
+} = {}) => {
   const leagueIdsValue = Array.isArray(league_ids)
     ? league_ids.join(',')
-    : (league_ids || '103,104');
+    : league_ids || '103,104';
 
   const params = new URLSearchParams({
     season,
     league_ids: leagueIdsValue,
-    team_id: team_id,
-    group: 'hitting',
+    team_id,
+    group,
     stat_type: statType,
     limit,
     offset,
@@ -147,83 +146,20 @@ export const fetchBattingLeaders = (
   return apiFetch(
     `/unified/get_leaderboard_data/?${params.toString()}`,
     {
-      cacheKey: `battingLeaders:${season}:${leagueIdsValue}:${team_id}:${statType}:${sortOrder}:${limit}:${offset}`,
+      cacheKey: `leaders:${group}:${season}:${leagueIdsValue}:${team_id}:${statType}:${sortOrder}:${limit}:${offset}`,
       ...opts,
     },
   );
 };
 
-export const fetchPitchingLeaders = (
-  season,
-  league_ids,
-  team_id,
-  statType,
-  sortOrder = 'asc',
-  limit = 10,
-  offset = 0,
-  {
-    ...opts
-  } = {},
-) => {
-  const leagueIdsValue = Array.isArray(league_ids)
-    ? league_ids.join(',')
-    : (league_ids || '103,104');
+export const fetchBattingLeaders = ({ sortOrder = 'desc', ...params } = {}) =>
+  fetchLeaders({ group: 'hitting', sortOrder, ...params });
 
-  const params = new URLSearchParams({
-    season,
-    league_ids: leagueIdsValue,
-    team_id: team_id,
-    group: 'pitching',
-    stat_type: statType,
-    limit,
-    offset,
-    sort_order: sortOrder,
-  });
+export const fetchPitchingLeaders = ({ sortOrder = 'asc', ...params } = {}) =>
+  fetchLeaders({ group: 'pitching', sortOrder, ...params });
 
-  return apiFetch(
-    `/unified/get_leaderboard_data/?${params.toString()}`,
-    {
-      cacheKey: `pitchingLeaders:${season}:${leagueIdsValue}:${team_id}:${statType}:${sortOrder}:${limit}:${offset}`,
-      ...opts,
-    },
-  );
-};
-
-export const fetchFieldingLeaders = (
-  season,
-  league_ids,
-  team_id,
-  statType,
-  sortOrder = 'desc',
-  limit = 10,
-  offset = 0,
-  {
-    ...opts
-  } = {},
-) => {
-  const leagueIdsValue = Array.isArray(league_ids)
-    ? league_ids.join(',')
-    : (league_ids || '103,104');
-
-  const params = new URLSearchParams({
-    season,
-    league_ids: leagueIdsValue,
-    team_id: team_id,
-    group: 'fielding',
-    stat_type: statType,
-    limit,
-    offset,
-    sort_order: sortOrder,
-  });
-
-    return apiFetch(
-      `/unified/get_leaderboard_data/?${params.toString()}`,
-      {
-        cacheKey: `fieldingLeaders:${season}:${leagueIdsValue}:${team_id}:${statType}:${sortOrder}:${limit}:${offset}`,
-        ...opts,
-      },
-    );
-  };
+export const fetchFieldingLeaders = ({ sortOrder = 'desc', ...params } = {}) =>
+  fetchLeaders({ group: 'fielding', sortOrder, ...params });
 
 export default {
   fetchTeamDetails,
@@ -237,6 +173,7 @@ export default {
   fetchTeamRecentSchedule,
   fetchTeamRoster,
   fetchTeamLeaders,
+  fetchLeaders,
   fetchBattingLeaders,
   fetchPitchingLeaders,
   fetchFieldingLeaders,

--- a/frontend/src/views/LeadersView.test.js
+++ b/frontend/src/views/LeadersView.test.js
@@ -47,7 +47,7 @@ function makeData(label) {
 
 describe('LeadersView filtering', () => {
   beforeEach(() => {
-    fetchBattingLeaders.mockImplementation((season, field, order, limit, offset, { leagueId, teamId } = {}) => {
+    fetchBattingLeaders.mockImplementation(({ league_ids: leagueId, team_id: teamId } = {}) => {
       if (teamId) return makeData(`Team ${teamId} Player`);
       if (leagueId) return makeData(`League ${leagueId} Player`);
       return makeData('All Player');
@@ -68,16 +68,16 @@ describe('LeadersView filtering', () => {
     await flushPromises();
 
     expect(fetchBattingLeaders).toHaveBeenCalledTimes(2);
-    const leagueOpts = fetchBattingLeaders.mock.calls[1][5];
-    expect(leagueOpts).toMatchObject({ leagueId: 103, teamId: null });
+    const leagueOpts = fetchBattingLeaders.mock.calls[1][0];
+    expect(leagueOpts).toMatchObject({ league_ids: 103, team_id: null });
     expect(wrapper.html()).toContain('League 103 Player');
 
     dropdowns[1].vm.$emit('update:modelValue', 133);
     await flushPromises();
 
     expect(fetchBattingLeaders).toHaveBeenCalledTimes(3);
-    const teamOpts = fetchBattingLeaders.mock.calls[2][5];
-    expect(teamOpts).toMatchObject({ leagueId: null, teamId: 133 });
+    const teamOpts = fetchBattingLeaders.mock.calls[2][0];
+    expect(teamOpts).toMatchObject({ league_ids: 103, team_id: 133 });
     expect(wrapper.html()).toContain('Team 133 Player');
   });
 });

--- a/frontend/src/views/LeadersView.vue
+++ b/frontend/src/views/LeadersView.vue
@@ -195,54 +195,48 @@ watch([selectedLeague, selectedTeam], async () => {
 async function loadBattingLeaders() {
   const season = new Date().getFullYear();
   const order = battingSort.value.order === 1 ? 'asc' : 'desc';
-  const data = await fetchBattingLeaders(
+  const data = await fetchBattingLeaders({
     season,
-    selectedLeague.value,
-    selectedTeam.value,
-    battingSort.value.field,
-    order,
-    10,
-    0,
-    {
-      useCache: false,     
-    },
-  );
+    league_ids: selectedLeague.value,
+    team_id: selectedTeam.value,
+    statType: battingSort.value.field,
+    sortOrder: order,
+    limit: 10,
+    offset: 0,
+    useCache: false,
+  });
   battingLeaders.value = Array.isArray(data) ? data : data?.stats || [];
 }
 
 async function loadPitchingLeaders() {
   const season = new Date().getFullYear();
   const order = pitchingSort.value.order === 1 ? 'asc' : 'desc';
-  const data = await fetchPitchingLeaders(
+  const data = await fetchPitchingLeaders({
     season,
-    selectedLeague.value,
-    selectedTeam.value,
-    pitchingSort.value.field,
-    order,
-    10,
-    0,
-    {
-      useCache: false,
-    },
-  );
+    league_ids: selectedLeague.value,
+    team_id: selectedTeam.value,
+    statType: pitchingSort.value.field,
+    sortOrder: order,
+    limit: 10,
+    offset: 0,
+    useCache: false,
+  });
   pitchingLeaders.value = Array.isArray(data) ? data : data?.stats || [];
 }
 
 async function loadFieldingLeaders() {
   const season = new Date().getFullYear();
   const order = fieldingSort.value.order === 1 ? 'asc' : 'desc';
-  const data = await fetchFieldingLeaders(
+  const data = await fetchFieldingLeaders({
     season,
-    selectedLeague.value,
-    selectedTeam.value,
-    fieldingSort.value.field,
-    order,
-    10,
-    0,
-    {
-      useCache: false,
-    },
-  );
+    league_ids: selectedLeague.value,
+    team_id: selectedTeam.value,
+    statType: fieldingSort.value.field,
+    sortOrder: order,
+    limit: 10,
+    offset: 0,
+    useCache: false,
+  });
   fieldingLeaders.value = Array.isArray(data) ? data : data?.stats || [];
 }
 


### PR DESCRIPTION
## Summary
- add generic `fetchLeaders` with shared URL, params, and cache handling
- replace batting/pitching/fielding leader functions with wrappers around `fetchLeaders`
- update views and tests to use new API signature

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8f5bd72448326a2732cb265b2ece8