### PR TITLE
refactor: centralize team stats styles

### DIFF
--- a/frontend/src/components/team/TeamHeader.vue
+++ b/frontend/src/components/team/TeamHeader.vue
@@ -88,41 +88,6 @@ const runDifferential = computed(() => teamRecord?.runDifferential ?? '');
   height: auto;
 }
 
-.stats-container {
-  background: rgba(255, 255, 255, 0.1);
-  border-radius: 0.5rem;
-  padding: 1rem;
-  margin: 0 auto 2rem;
-  max-width: 100%;
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-}
-
-.stats-container:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
-}
-
-.team-stats {
-  border-collapse: collapse;
-  font-family: var(--font-base);
-  font-size: 1.6rem;
-  width: 100%;
-}
-
-.team-stats th,
-.team-stats td {
-  border: 2px solid var(--color-accent);
-  padding: 0.5rem 1rem;
-  text-align: center;
-}
-
-.team-stats th {
-  background-color: var(--color-accent);
-  color: var(--color-primary);
-  font-weight: 600;
-}
-
 .team-header .team-stats th {
   color: white;
 }

--- a/frontend/src/components/team/TeamLeaders.vue
+++ b/frontend/src/components/team/TeamLeaders.vue
@@ -51,19 +51,4 @@ const { leaders } = defineProps({
   flex-wrap: wrap;
   margin-top: 1rem;
 }
-
-.stats-container {
-  background: rgba(255, 255, 255, 0.1);
-  border-radius: 0.5rem;
-  padding: 1rem;
-  margin: 0 auto 2rem;
-  max-width: 100%;
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-}
-
-.stats-container:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
-}
 </style>

--- a/frontend/src/components/team/TeamRoster.vue
+++ b/frontend/src/components/team/TeamRoster.vue
@@ -125,45 +125,10 @@ const battersByPosition = computed(() => {
   flex-wrap: wrap;
 }
 
-.stats-container {
-  background: rgba(255, 255, 255, 0.1);
-  border-radius: 0.5rem;
-  padding: 1rem;
-  margin: 0 auto 2rem;
-  max-width: 100%;
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-}
-
-.stats-container:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
-}
-
 .roster {
   flex: 1 1 45%;
   margin: 0 auto 1rem;
   padding: 0.5rem;
-}
-
-.team-stats {
-  border-collapse: collapse;
-  font-family: var(--font-base);
-  font-size: 1.6rem;
-  width: 100%;
-}
-
-.team-stats th,
-.team-stats td {
-  border: 2px solid var(--color-accent);
-  padding: 0.5rem 1rem;
-  text-align: center;
-}
-
-.team-stats th {
-  background-color: var(--color-accent);
-  color: var(--color-primary);
-  font-weight: 600;
 }
 
 .roster-table {

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -59,3 +59,39 @@ a:hover {
   padding: 0 1rem;
 }
 
+/* Shared stats styles */
+.stats-container {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  margin: 0 auto 2rem;
+  max-width: 100%;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.stats-container:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+}
+
+.team-stats {
+  border-collapse: collapse;
+  font-family: var(--font-base);
+  font-size: 1.6rem;
+  width: 100%;
+}
+
+.team-stats th,
+.team-stats td {
+  border: 2px solid var(--color-accent);
+  padding: 0.5rem 1rem;
+  text-align: center;
+}
+
+.team-stats th {
+  background-color: var(--color-accent);
+  color: var(--color-primary);
+  font-weight: 600;
+}
+

--- a/frontend/src/views/TeamView.vue
+++ b/frontend/src/views/TeamView.vue
@@ -236,42 +236,6 @@ async function loadTeamDetails(mlbam_team_id, force = false) {
   max-width: 1100px;
   margin: 0 auto;
 }
-
-.stats-container {
-  background: rgba(255, 255, 255, 0.1);
-  border-radius: 0.5rem;
-  padding: 1rem;
-  margin: 0 auto 2rem;
-  max-width: 100%;
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-}
-
-.stats-container:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
-}
-
-.team-stats {
-  border-collapse: collapse;
-  font-family: var(--font-base);
-  font-size: 1.6rem;
-  width: 100%;
-}
-
-.team-stats th,
-.team-stats td {
-  border: 2px solid var(--color-accent);
-  padding: 0.5rem 1rem;
-  text-align: center;
-}
-
-.team-stats th {
-  background-color: var(--color-accent);
-  color: var(--color-primary);
-  font-weight: 600;
-}
-
 .division-standings thead th {
   background-color: var(--color-primary);
   color: #fff;


### PR DESCRIPTION
## Summary
- centralize shared `.stats-container` and `.team-stats` rules in `global.css`
- strip duplicated style blocks from team components and keep only unique overrides

## Testing
- `npm test`
- `pytest` *(fails: TypeError: can only concatenate str (not "NoneType") to str)*

------
https://chatgpt.com/codex/tasks/task_e_68b8fe0005ac832695d58b728f1ceaef