### PR TITLE
Default to descending sort when selecting new Leaders column

### DIFF
--- a/frontend/src/views/LeadersView.test.js
+++ b/frontend/src/views/LeadersView.test.js
@@ -82,3 +82,31 @@ describe('LeadersView filtering', () => {
   });
 });
 
+describe('LeadersView sorting', () => {
+  beforeEach(() => {
+    fetchBattingLeaders.mockReset();
+    fetchPitchingLeaders.mockResolvedValue([]);
+    fetchFieldingLeaders.mockResolvedValue([]);
+    fetchBattingLeaders.mockResolvedValue([
+      { rank: 1, playerFullName: 'A', teamAbbrev: 'T' },
+    ]);
+  });
+
+  it('sorts new columns in descending order first', async () => {
+    const { default: LeadersView } = await import('./LeadersView.vue');
+    const wrapper = mount(LeadersView);
+
+    await flushPromises();
+
+    fetchBattingLeaders.mockClear();
+
+    const dt = wrapper.findAllComponents(DataTableStub)[0];
+    dt.vm.$emit('sort', { sortField: 'avg', sortOrder: 1 });
+    await flushPromises();
+
+    expect(fetchBattingLeaders).toHaveBeenCalledTimes(1);
+    const opts = fetchBattingLeaders.mock.calls[0][0];
+    expect(opts).toMatchObject({ statType: 'avg', sortOrder: 'desc' });
+  });
+});
+

--- a/frontend/src/views/LeadersView.vue
+++ b/frontend/src/views/LeadersView.vue
@@ -241,17 +241,20 @@ async function loadFieldingLeaders() {
 }
 
 function onBattingSort(e) {
-  battingSort.value = { field: e.sortField, order: e.sortOrder };
+  const order = e.sortField === battingSort.value.field ? e.sortOrder : -1;
+  battingSort.value = { field: e.sortField, order };
   loadBattingLeaders();
 }
 
 function onPitchingSort(e) {
-  pitchingSort.value = { field: e.sortField, order: e.sortOrder };
+  const order = e.sortField === pitchingSort.value.field ? e.sortOrder : -1;
+  pitchingSort.value = { field: e.sortField, order };
   loadPitchingLeaders();
 }
 
 function onFieldingSort(e) {
-  fieldingSort.value = { field: e.sortField, order: e.sortOrder };
+  const order = e.sortField === fieldingSort.value.field ? e.sortOrder : -1;
+  fieldingSort.value = { field: e.sortField, order };
   loadFieldingLeaders();
 }
 </script>


### PR DESCRIPTION
## Summary
- Ensure clicking a new column header on the Leaders page sorts data descending by default
- Add test verifying first sort direction for new columns

## Testing
- `npm test`
- `pytest` *(fails: TypeError in Django test setup due to missing database name)*

------
https://chatgpt.com/codex/tasks/task_e_68b9020c8d1c8326b96167b67b2bfdbe