### PR TITLE
Fix Leaders column sorting toggle

### DIFF
--- a/frontend/src/views/LeadersView.test.js
+++ b/frontend/src/views/LeadersView.test.js
@@ -108,5 +108,24 @@ describe('LeadersView sorting', () => {
     const opts = fetchBattingLeaders.mock.calls[0][0];
     expect(opts).toMatchObject({ statType: 'avg', sortOrder: 'desc' });
   });
+
+  it('toggles sort order when clicking the same column again', async () => {
+    const { default: LeadersView } = await import('./LeadersView.vue');
+    const wrapper = mount(LeadersView);
+
+    await flushPromises();
+
+    fetchBattingLeaders.mockClear();
+
+    const dt = wrapper.findAllComponents(DataTableStub)[0];
+    dt.vm.$emit('sort', { sortField: 'avg', sortOrder: 1 });
+    await flushPromises();
+    dt.vm.$emit('sort', { sortField: 'avg', sortOrder: 1 });
+    await flushPromises();
+
+    expect(fetchBattingLeaders).toHaveBeenCalledTimes(2);
+    const opts = fetchBattingLeaders.mock.calls[1][0];
+    expect(opts).toMatchObject({ statType: 'avg', sortOrder: 'asc' });
+  });
 });
 

--- a/frontend/src/views/LeadersView.vue
+++ b/frontend/src/views/LeadersView.vue
@@ -241,19 +241,28 @@ async function loadFieldingLeaders() {
 }
 
 function onBattingSort(e) {
-  const order = e.sortField === battingSort.value.field ? e.sortOrder : -1;
+  const order =
+    e.sortField === battingSort.value.field
+      ? battingSort.value.order * -1
+      : -1;
   battingSort.value = { field: e.sortField, order };
   loadBattingLeaders();
 }
 
 function onPitchingSort(e) {
-  const order = e.sortField === pitchingSort.value.field ? e.sortOrder : -1;
+  const order =
+    e.sortField === pitchingSort.value.field
+      ? pitchingSort.value.order * -1
+      : -1;
   pitchingSort.value = { field: e.sortField, order };
   loadPitchingLeaders();
 }
 
 function onFieldingSort(e) {
-  const order = e.sortField === fieldingSort.value.field ? e.sortOrder : -1;
+  const order =
+    e.sortField === fieldingSort.value.field
+      ? fieldingSort.value.order * -1
+      : -1;
   fieldingSort.value = { field: e.sortField, order };
   loadFieldingLeaders();
 }


### PR DESCRIPTION
## Summary
- Toggle sort order when clicking the same column on Leaders page
- Test column sort toggling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9039eb26c83269a6df3c7e6c60c11