### PR TITLE
refactor: centralize stats table styles

### DIFF
--- a/frontend/src/components/PlayerGameLog.vue
+++ b/frontend/src/components/PlayerGameLog.vue
@@ -102,15 +102,6 @@ const navigateToGame = (pk) => {
 <style scoped>
 .stats-table {
   margin-top: 1rem;
-  border-collapse: collapse;
-}
-.stats-table th,
-.stats-table td {
-  border: 1px solid #ddd;
-  padding: 0.5rem;
-}
-.stats-table th {
-  background-color: #f5f5f5;
 }
 
 .month-row td {

--- a/frontend/src/components/PlayerSplits.vue
+++ b/frontend/src/components/PlayerSplits.vue
@@ -185,19 +185,7 @@ const pitchingRowsBySplit = computed(() => {
   margin-top: 2rem;
 }
 .stats-table {
-  width: 100%;
-  border-collapse: collapse;
   margin-bottom: 2rem;
-}
-.stats-table th,
-.stats-table td {
-  padding: 0.5rem;
-  border: 1px solid rgba(0, 0, 0, 0.1);
-  text-align: center;
-}
-.stats-table th {
-  background: var(--color-primary);
-  color: #fff;
 }
 
 .group-separator td {

--- a/frontend/src/components/PlayerStats.vue
+++ b/frontend/src/components/PlayerStats.vue
@@ -199,19 +199,7 @@ const advancedPitchingRows = computed(() => {
   margin-top: 2rem;
 }
 .stats-table {
-  width: 100%;
-  border-collapse: collapse;
   margin-bottom: 1.5rem;
-}
-.stats-table th,
-.stats-table td {
-  padding: 0.5rem;
-  border: 1px solid rgba(0,0,0,0.1);
-  text-align: center;
-}
-.stats-table th {
-  background: var(--color-primary);
-  color: #fff;
 }
 .stats-table tr.career-total {
   background: #e6f7ff;

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -95,3 +95,22 @@ a:hover {
   font-weight: 600;
 }
 
+/* Shared stats table styles */
+.stats-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.stats-table th,
+.stats-table td {
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  padding: 0.5rem;
+  text-align: center;
+}
+
+.stats-table th {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+


### PR DESCRIPTION
## Summary
- extract shared `.stats-table` styles to global stylesheet
- remove duplicate table CSS from game log, splits, and stats components

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b905590b9c832689e9987275541adb