### PR TITLE
Fix schedule's timezone handling

### DIFF
--- a/frontend/src/composables/useSchedule.js
+++ b/frontend/src/composables/useSchedule.js
@@ -76,7 +76,9 @@ export function useSchedule() {
   const scheduleStore = useScheduleStore();
   const { schedule } = storeToRefs(scheduleStore);
 
-  const today = new Date().toISOString().slice(0, 10);
+  const today = new Intl.DateTimeFormat('en-CA', {
+    timeZone: TIME_ZONE,
+  }).format(new Date());
 
   const games = shallowRef([]);
   const loading = ref(false);

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -81,13 +81,17 @@ const features = [
 const schedulePreview = ref([]);
 const standingsPreview = ref([]);
 
+const TIME_ZONE = 'America/New_York';
+
 function formatTime(dateStr) {
   const d = new Date(dateStr);
   return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 }
 
 onMounted(async () => {
-  const today = new Date().toISOString().split('T')[0];
+  const today = new Intl.DateTimeFormat('en-CA', { timeZone: TIME_ZONE }).format(
+    new Date(),
+  );
   const [schedData, standingsData] = await Promise.all([
     fetchSchedule(today),
     fetchStandings(),


### PR DESCRIPTION
## Summary
- Ensure schedule uses America/New_York when determining today's date
- Apply same timezone logic to home schedule preview

## Testing
- `npm test`
- `pytest` *(fails: TypeError: can only concatenate str (not "NoneType") to str)*

------
https://chatgpt.com/codex/tasks/task_e_68b906df8b888326bb1b8238e33e8aae