### PR TITLE
feat: extract loading dialog component

### DIFF
--- a/frontend/src/components.d.ts
+++ b/frontend/src/components.d.ts
@@ -13,6 +13,7 @@ declare module 'vue' {
     GameRow: typeof import('./components/GameRow.vue')['default']
     HelloComponent: typeof import('./components/HelloComponent.vue')['default']
     JsonViewer: typeof import('./components/JsonViewer.vue')['default']
+    LoadingDialog: typeof import('./components/LoadingDialog.vue')['default']
     PlayerGameLog: typeof import('./components/PlayerGameLog.vue')['default']
     PlayerQuickList: typeof import('./components/PlayerQuickList.vue')['default']
     PlayerSplits: typeof import('./components/PlayerSplits.vue')['default']

--- a/frontend/src/components/LoadingDialog.vue
+++ b/frontend/src/components/LoadingDialog.vue
@@ -1,0 +1,41 @@
+<template>
+  <Dialog
+    :visible="visible"
+    modal
+    :closable="false"
+    :draggable="false"
+    :dismissableMask="false"
+    :closeOnEscape="false"
+    class="loading-dialog"
+  >
+    <div class="loading-content">
+      <ProgressSpinner />
+      <p>Loading data...</p>
+    </div>
+  </Dialog>
+</template>
+
+<script setup>
+import Dialog from 'primevue/dialog';
+import 'primevue/dialog/style';
+import ProgressSpinner from 'primevue/progressspinner';
+import 'primevue/progressspinner/style';
+
+defineProps({
+  visible: {
+    type: Boolean,
+    default: false,
+  },
+});
+</script>
+
+<style scoped>
+.loading-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem;
+}
+</style>
+

--- a/frontend/src/views/PlayerView.vue
+++ b/frontend/src/views/PlayerView.vue
@@ -82,20 +82,7 @@
         </TabPanel>
       </TabView>
     </div>
-    <Dialog
-      v-model:visible="loading"
-      modal
-      :closable="false"
-      :draggable="false"
-      :dismissableMask="false"
-      :closeOnEscape="false"
-      class="loading-dialog"
-    >
-      <div class="loading-content">
-        <ProgressSpinner />
-        <p>Loading data...</p>
-      </div>
-    </Dialog>
+    <LoadingDialog :visible="loading" />
   </section>
 </template>
 
@@ -106,10 +93,7 @@ import PlayerSplits from '../components/PlayerSplits.vue';
 import PlayerGameLog from '../components/PlayerGameLog.vue';
 import TabView from 'primevue/tabview';
 import TabPanel from 'primevue/tabpanel';
-import Dialog from 'primevue/dialog';
-import 'primevue/dialog/style';
-import ProgressSpinner from 'primevue/progressspinner';
-import 'primevue/progressspinner/style';
+import LoadingDialog from '../components/LoadingDialog.vue';
 import teamColors from '../data/teamColors.json';
 import { fetchPlayer } from '../services/api.js';
 
@@ -325,11 +309,4 @@ onMounted(async () => {
   color: inherit;
 }
 
-.loading-content {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 1rem;
-  padding: 1rem;
-}
 </style>

--- a/frontend/src/views/TeamView.vue
+++ b/frontend/src/views/TeamView.vue
@@ -51,20 +51,7 @@
         </TabPanel>
       </TabView>
     </div>
-    <Dialog
-      v-model:visible="loading"
-      modal
-      :closable="false"
-      :draggable="false"
-      :dismissableMask="false"
-      :closeOnEscape="false"
-      class="loading-dialog"
-    >
-      <div class="loading-content">
-        <ProgressSpinner />
-        <p>Loading data...</p>
-      </div>
-    </Dialog>
+    <LoadingDialog :visible="loading" />
   </section>
 </template>
 
@@ -73,10 +60,7 @@ import { ref, watch, onMounted, computed } from 'vue';
 import TabView from 'primevue/tabview';
 import TabPanel from 'primevue/tabpanel';
 import Skeleton from 'primevue/skeleton';
-import Dialog from 'primevue/dialog';
-import 'primevue/dialog/style';
-import ProgressSpinner from 'primevue/progressspinner';
-import 'primevue/progressspinner/style';
+import LoadingDialog from '../components/LoadingDialog.vue';
 import TeamHeader from '../components/team/TeamHeader.vue';
 import TeamLeaders from '../components/team/TeamLeaders.vue';
 import TeamRoster from '../components/team/TeamRoster.vue';
@@ -247,11 +231,4 @@ async function loadTeamDetails(mlbam_team_id, force = false) {
   font-weight: 600;
 }
 
-.loading-content {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 1rem;
-  padding: 1rem;
-}
 </style>


### PR DESCRIPTION
## Summary
- create reusable `LoadingDialog` component with spinner and styles
- replace inline loading dialogs in TeamView and PlayerView with component
- centralize `.loading-content` styles inside component

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b91611078883268405073277604b7e