### PR TITLE
refactor: share team abbreviation cache

### DIFF
--- a/frontend/src/components/PlayerSplits.vue
+++ b/frontend/src/components/PlayerSplits.vue
@@ -97,9 +97,10 @@
 
 <script setup>
 import { ref, onMounted, computed } from 'vue';
-import { fetchPlayerSplits, fetchTeamDetails } from '../services/api.js';
+import { fetchPlayerSplits } from '../services/api.js';
 import logger from '../utils/logger';
 import { teamAbbrev } from '../composables/gameHelpers.js';
+import { teamAbbrevs, fetchTeamAbbrevs } from '../utils/teamAbbrevs.js';
 import {
   standardHittingFields,
   advancedHittingFields,
@@ -113,13 +114,21 @@ import {
 const { id } = defineProps({ id: String });
 
 const data = ref(null);
-const teamAbbrevs = ref({});
 
 onMounted(async () => {
   logger.info('Fetching player splits for ID:', id);
   data.value = await fetchPlayerSplits(id);
   logger.info('Fetched player splits:', data.value);
-  await fetchTeamAbbrevs();
+  const ids = new Set();
+  batting.value.forEach(r => {
+    const tid = r.team?.id;
+    if (tid) ids.add(tid);
+  });
+  monthlyBatting.value.forEach(r => {
+    const tid = r.team?.id;
+    if (tid) ids.add(tid);
+  });
+  await fetchTeamAbbrevs(ids);
 });
 const batting = computed(() => data.value?.batting || []);
 const pitching = computed(() => data.value?.pitching || []);
@@ -131,25 +140,6 @@ const monthlyPitching = computed(() => {
   const splits = data.value?.monthly?.pitching || [];
   return [...splits].sort((a, b) => (a.month ?? 0) - (b.month ?? 0));
 });
-
-async function fetchTeamAbbrevs() {
-  const ids = new Set();
-  batting.value.forEach(r => {
-    const tid = r.team?.id;
-    if (tid) ids.add(tid);
-  });
-  monthlyBatting.value.forEach(r => {
-    const tid = r.team?.id;
-    if (tid) ids.add(tid);
-  });
-  await Promise.all(
-    Array.from(ids).map(async tid => {
-      if (teamAbbrevs.value[tid]) return;
-      const tdata = await fetchTeamDetails(tid);
-      if (tdata) teamAbbrevs.value[tid] = tdata.abbrev || tid;
-    })
-  );
-}
 
 const teamLabel = team => {
   const tid = team?.id;

--- a/frontend/src/components/PlayerStats.vue
+++ b/frontend/src/components/PlayerStats.vue
@@ -96,39 +96,25 @@ import {
   advancedPitchingFields,
   fieldLabels
 } from '../config/playerStatsConfig.js';
-import { fetchPlayerStats, fetchTeamDetails } from '../services/api.js';
+import { fetchPlayerStats } from '../services/api.js';
+import { teamAbbrevs, fetchTeamAbbrevs } from '../utils/teamAbbrevs.js';
 
 
 const { id } = defineProps({ id: String });
 
 const stats = ref(null);
-const teamAbbrevs = ref({});
 
 onMounted(async () => {
   stats.value = await fetchPlayerStats(id);
-  await fetchTeamAbbrevs(stats.value?.stats);
-});
-
-
-
-async function fetchTeamAbbrevs(statGroups) {
   const ids = new Set();
-  statGroups?.forEach(group => {
+  stats.value?.stats?.forEach(group => {
     group?.splits?.forEach(split => {
       const tid = split.team?.id;
       if (tid) ids.add(tid);
     });
   });
-  await Promise.all(
-    Array.from(ids).map(async tid => {
-      if (teamAbbrevs.value[tid]) return;
-      const data = await fetchTeamDetails(tid);
-      if (data) {
-        teamAbbrevs.value[tid] = data.abbrev || tid;
-      }
-    })
-  );
-}
+  await fetchTeamAbbrevs(ids);
+});
 
 function buildRows(statData, fields, defaultLabel) {
   const splits = statData?.splits || [];

--- a/frontend/src/utils/teamAbbrevs.js
+++ b/frontend/src/utils/teamAbbrevs.js
@@ -1,0 +1,30 @@
+import { ref } from 'vue';
+import { fetchTeamDetails } from '../services/api.js';
+
+// Shared cache for team abbreviations. Components importing this module will
+// reuse the same ref instance, avoiding duplicate network requests.
+export const teamAbbrevs = ref({});
+
+/**
+ * Fetch and cache abbreviations for the given team IDs.
+ *
+ * @param {Iterable<number|string>} ids - collection of team IDs to fetch
+ * @returns {Promise<Object>} resolved with the updated cache map
+ */
+export async function fetchTeamAbbrevs(ids) {
+  const toFetch = [];
+  ids && Array.from(ids).forEach(id => {
+    if (!teamAbbrevs.value[id]) toFetch.push(id);
+  });
+  await Promise.all(
+    toFetch.map(async tid => {
+      const data = await fetchTeamDetails(tid);
+      if (data) {
+        teamAbbrevs.value[tid] = data.abbrev || tid;
+      }
+    })
+  );
+  return teamAbbrevs.value;
+}
+
+export default { teamAbbrevs, fetchTeamAbbrevs };


### PR DESCRIPTION
## Summary
- add shared team abbreviation utility and cache
- refactor PlayerStats and PlayerSplits to use shared cache

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b916a6aa70832691a5af64e3d1f4e7