### PR TITLE
refactor: centralize team color styling

### DIFF
--- a/frontend/src/composables/README.md
+++ b/frontend/src/composables/README.md
@@ -1,3 +1,10 @@
 # Composables
 
 This directory houses reusable Vue composable functions.
+
+## useTeamColors
+
+`useTeamColors(nameRef)` returns a reactive style object containing CSS
+variables for a team's primary, secondary and accent colors. Pass a team name
+or a ref to one and use the returned object to theme components based on the
+selected team.

--- a/frontend/src/composables/useTeamColors.js
+++ b/frontend/src/composables/useTeamColors.js
@@ -1,0 +1,25 @@
+import { computed, unref } from 'vue';
+import teamColors from '../data/teamColors.json';
+
+/**
+ * Provides reactive CSS variables for a team's colors.
+ *
+ * Accepts a ref or value containing the team name and returns a computed
+ * style object with `--color-primary`, `--color-secondary` and
+ * `--color-accent` variables. Defaults match the site's theme and allow the
+ * composable to be reused wherever team-based theming is needed.
+ *
+ * @param {import('vue').MaybeRef<string>} nameRef - team name or ref to it
+ * @returns {import('vue').ComputedRef<Record<string, string>>}
+ */
+export function useTeamColors(nameRef) {
+  return computed(() => {
+    const name = unref(nameRef);
+    const colors = teamColors[name] || [];
+    return {
+      '--color-primary': colors[0]?.hex || '#1e3a8a',
+      '--color-secondary': colors[1]?.hex || '#1e40af',
+      '--color-accent': colors[2]?.hex || '#fbbf24'
+    };
+  });
+}

--- a/frontend/src/views/PlayerView.vue
+++ b/frontend/src/views/PlayerView.vue
@@ -94,7 +94,7 @@ import PlayerGameLog from '../components/PlayerGameLog.vue';
 import TabView from 'primevue/tabview';
 import TabPanel from 'primevue/tabpanel';
 import LoadingDialog from '../components/LoadingDialog.vue';
-import teamColors from '../data/teamColors.json';
+import { useTeamColors } from '../composables/useTeamColors.js';
 import { fetchPlayer } from '../services/api.js';
 
 const { id } = defineProps({
@@ -119,14 +119,7 @@ const loading = ref(true);
 
 const statType = computed(() => (position.value === 'Pitcher' ? 'pitching' : 'hitting'));
 
-const teamColorStyle = computed(() => {
-  const colors = teamColors[teamName.value] || [];
-  return {
-    '--color-primary': colors[0]?.hex || '#1e3a8a',
-    '--color-secondary': colors[1]?.hex || '#1e40af',
-    '--color-accent': colors[2]?.hex || '#fbbf24'
-  };
-});
+const teamColorStyle = useTeamColors(teamName);
 
 const formattedBirthDate = computed(() => {
   if (!birthDate.value) return '';

--- a/frontend/src/views/TeamView.vue
+++ b/frontend/src/views/TeamView.vue
@@ -56,7 +56,7 @@
 </template>
 
 <script setup>
-import { ref, watch, onMounted, computed } from 'vue';
+import { ref, watch, onMounted } from 'vue';
 import TabView from 'primevue/tabview';
 import TabPanel from 'primevue/tabpanel';
 import Skeleton from 'primevue/skeleton';
@@ -65,7 +65,7 @@ import TeamHeader from '../components/team/TeamHeader.vue';
 import TeamLeaders from '../components/team/TeamLeaders.vue';
 import TeamRoster from '../components/team/TeamRoster.vue';
 import TeamSchedule from '../components/team/TeamSchedule.vue';
-import teamColors from '../data/teamColors.json';
+import { useTeamColors } from '../composables/useTeamColors.js';
 import { useTeamsStore } from '../store/teams';
 import { useCachedFetch } from '../composables/useCachedFetch';
 import deepEqual from '../utils/deepEqual.js';
@@ -94,14 +94,7 @@ const leaders = ref(null);
 const loading = ref(true);
 const teamsStore = useTeamsStore();
 
-const teamColorStyle = computed(() => {
-  const colors = teamColors[name] || [];
-  return {
-    '--color-primary': colors[0]?.hex || '#1e3a8a',
-    '--color-secondary': colors[1]?.hex || '#1e40af',
-    '--color-accent': colors[2]?.hex || '#1e3a8a'
-  };
-});
+const teamColorStyle = useTeamColors(name);
 
 async function loadLogo(mlbam_team_id) {
   const url = await fetchTeamLogo(mlbam_team_id);


### PR DESCRIPTION
## Summary
- add reusable `useTeamColors` composable for team color CSS variables
- update TeamView and PlayerView to use shared color hook
- document new composable for future theming

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9c7d76a508326be04f6c01464a4e7