### PR TITLE
Fix schedule test to avoid hanging

### DIFF
--- a/backend/apps/api/tests/test_schedule.py
+++ b/backend/apps/api/tests/test_schedule.py
@@ -20,7 +20,13 @@ class ScheduleApiTests(TestCase):
                 ]
             }
         ]
-        mock_client.fetch_team_spot_url.return_value = 'logo-url'
+        # The production code calls ``get_team_spot_url`` to obtain a team's
+        # logo.  The previous version of this test patched the non-existent
+        # ``fetch_team_spot_url`` method which left a ``MagicMock`` object in
+        # the response and caused the test client to hang during JSON
+        # serialisation.  Patch the correct method so a simple string is
+        # injected into the response data.
+        mock_client.get_team_spot_url.return_value = 'logo-url'
 
         response = self.client.get('/api/schedule/', {'date': '2025-08-18'})
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## Summary
- Update schedule API test to patch `get_team_spot_url` instead of a non-existent method so the JSON response contains a simple string and the test no longer hangs.

## Testing
- `pytest -k test_schedule -vv`
- `pytest -x -q` *(fails: TeamLogoApiTests::test_team_logo_endpoint)*

------
https://chatgpt.com/codex/tasks/task_e_68bb467c3dec832683ed9d26dbb5b76d