### PR TITLE
feat: add hall of fame page and nav link

### DIFF
--- a/frontend/src/layouts/BaseLayout.vue
+++ b/frontend/src/layouts/BaseLayout.vue
@@ -7,6 +7,7 @@
       <RouterLink to="/teams">Teams</RouterLink>
       <RouterLink to="/players">Players</RouterLink>
       <RouterLink to="/leaders">Leaders</RouterLink>
+      <RouterLink to="/hall-of-fame">Hall of Fame</RouterLink>
       <RouterLink to="/developer" class="developer-link">Developer</RouterLink>
     </nav>
     <div class="page-wrapper">

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -44,6 +44,11 @@ const routes = [
     component: () => import('../views/LeadersView.vue')
   },
   {
+    path: '/hall-of-fame',
+    name: 'HallOfFame',
+    component: () => import('../views/HallOfFameView.vue')
+  },
+  {
     path: '/player/:id',
     name: 'Player',
     component: () => import('../views/PlayerView.vue'),

--- a/frontend/src/views/HallOfFameView.vue
+++ b/frontend/src/views/HallOfFameView.vue
@@ -1,0 +1,15 @@
+<template>
+  <section class="hall-of-fame-view">
+    <h1>Hall of Fame</h1>
+  </section>
+</template>
+
+<script setup>
+// Content will be added in future iterations
+</script>
+
+<style scoped>
+.hall-of-fame-view {
+  padding: 1rem;
+}
+</style>


### PR DESCRIPTION
## Summary
- add Hall of Fame link to top navigation
- create Hall of Fame view and route

## Testing
- `npm test`
- `pytest` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68bb470fc12c8326a6432726325ed534