### PR TITLE
Add tests for Hall of Fame players endpoint

### DIFF
--- a/backend/apps/api/tests/test_halloffame.py
+++ b/backend/apps/api/tests/test_halloffame.py
@@ -1,0 +1,24 @@
+from django.test import TestCase, Client
+
+from apps.api.models import HallOfFameVote, PlayerIdInfo
+
+
+class HallOfFamePlayersApiTests(TestCase):
+    def setUp(self):
+        self.client = Client(HTTP_HOST='localhost')
+
+    def test_returns_inducted_players_with_mlbam_ids(self):
+        HallOfFameVote.objects.create(bbref_id='ruthba01', year=1936, inducted=True, category='Player')
+        HallOfFameVote.objects.create(bbref_id='doejo01', year=2000, inducted=True, category='Player')
+        HallOfFameVote.objects.create(bbref_id='notind01', year=1990, inducted=False, category='Player')
+        HallOfFameVote.objects.create(bbref_id='manager01', year=1988, inducted=True, category='Manager')
+
+        PlayerIdInfo.objects.create(key_bbref='ruthba01', key_mlbam='12345')
+
+        response = self.client.get('/api/players/halloffame/')
+        self.assertEqual(response.status_code, 200)
+        players = response.json()['players']
+
+        self.assertEqual(len(players), 2)
+        self.assertIn({'bbref_id': 'ruthba01', 'year': 1936, 'mlbam_id': '12345'}, players)
+        self.assertIn({'bbref_id': 'doejo01', 'year': 2000, 'mlbam_id': None}, players)

--- a/backend/apps/api/views/halloffame.py
+++ b/backend/apps/api/views/halloffame.py
@@ -1,11 +1,12 @@
 from rest_framework.decorators import api_view
+from rest_framework.response import Response
 
 from ..models import HallOfFameVote
 from ..models import PlayerIdInfo
 
 
 @api_view(['GET'])
-def hall_of_fame_players(request):
+def hall_of_fame_players(request, hall_of_fame=False):  # noqa: F841 - hall_of_fame unused
     # enrich each inducted Player with mlbam_id from PlayerIdInfo by bbref_id
 
     players = list(
@@ -18,13 +19,13 @@ def hall_of_fame_players(request):
     mlbam_map = dict(
         PlayerIdInfo.objects
         .filter(key_bbref__in=bbref_ids)
-        .values_list('key_bbref', 'mlbam_id')
+        .values_list('key_bbref', 'key_mlbam')
     )
 
     for p in players:
         p['mlbam_id'] = mlbam_map.get(p['bbref_id'])
 
-    return {'players': players}
+    return Response({'players': players})
 
 
 


### PR DESCRIPTION
## Summary
- fix hall of fame players view to use `key_mlbam`, accept extra arg, and return a DRF response
- add test covering Hall of Fame players endpoint

## Testing
- `python backend/manage.py test apps.api.tests.test_halloffame -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68bdf9e10f008326b01590fe1b486e0c