### PR TITLE
Add Hall of Fame player table

### DIFF
--- a/backend/apps/api/tests/test_halloffame.py
+++ b/backend/apps/api/tests/test_halloffame.py
@@ -13,12 +13,23 @@ class HallOfFamePlayersApiTests(TestCase):
         HallOfFameVote.objects.create(bbref_id='notind01', year=1990, inducted=False, category='Player')
         HallOfFameVote.objects.create(bbref_id='manager01', year=1988, inducted=True, category='Manager')
 
-        PlayerIdInfo.objects.create(key_bbref='ruthba01', key_mlbam='12345')
+        PlayerIdInfo.objects.create(
+            key_bbref='ruthba01', key_mlbam='12345', name_first='Babe', name_last='Ruth'
+        )
+        PlayerIdInfo.objects.create(
+            key_bbref='doejo01', name_first='John', name_last='Doe'
+        )
 
         response = self.client.get('/api/players/halloffame/')
         self.assertEqual(response.status_code, 200)
         players = response.json()['players']
 
         self.assertEqual(len(players), 2)
-        self.assertIn({'bbref_id': 'ruthba01', 'year': 1936, 'mlbam_id': '12345'}, players)
-        self.assertIn({'bbref_id': 'doejo01', 'year': 2000, 'mlbam_id': None}, players)
+        self.assertIn(
+            {'bbref_id': 'ruthba01', 'year': 1936, 'mlbam_id': '12345', 'name': 'Babe Ruth'},
+            players,
+        )
+        self.assertIn(
+            {'bbref_id': 'doejo01', 'year': 2000, 'mlbam_id': None, 'name': 'John Doe'},
+            players,
+        )

--- a/backend/apps/api/views/halloffame.py
+++ b/backend/apps/api/views/halloffame.py
@@ -16,14 +16,20 @@ def hall_of_fame_players(request):  # noqa: F841 - hall_of_fame unused
     )
 
     bbref_ids = [p['bbref_id'] for p in players if p['bbref_id']]
-    mlbam_map = dict(
-        PlayerIdInfo.objects
+    info_map = {
+        bbref: {
+            'mlbam_id': mlbam,
+            'name': name,
+        }
+        for bbref, mlbam, name in PlayerIdInfo.objects
         .filter(key_bbref__in=bbref_ids)
-        .values_list('key_bbref', 'key_mlbam')
-    )
+        .values_list('key_bbref', 'key_mlbam', 'name_full')
+    }
 
     for p in players:
-        p['mlbam_id'] = mlbam_map.get(p['bbref_id'])
+        info = info_map.get(p['bbref_id'], {})
+        p['mlbam_id'] = info.get('mlbam_id')
+        p['name'] = info.get('name')
 
     return Response({'players': players})
 

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -161,6 +161,9 @@ export const fetchPitchingLeaders = ({ sortOrder = 'asc', ...params } = {}) =>
 export const fetchFieldingLeaders = ({ sortOrder = 'desc', ...params } = {}) =>
   fetchLeaders({ group: 'fielding', sortOrder, ...params });
 
+export const fetchHallOfFamePlayers = (opts) =>
+  apiFetch('/players/halloffame/', { cacheKey: 'hallOfFame', ...opts });
+
 export default {
   fetchTeamDetails,
   fetchTeamLogo,
@@ -177,6 +180,7 @@ export default {
   fetchBattingLeaders,
   fetchPitchingLeaders,
   fetchFieldingLeaders,
+  fetchHallOfFamePlayers,
   fetchPlayerSplits,
   fetchPlayerGameLog,
 };

--- a/frontend/src/views/HallOfFameView.test.js
+++ b/frontend/src/views/HallOfFameView.test.js
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+
+const fetchHallOfFamePlayers = vi.fn();
+
+vi.mock('../services/api', () => ({
+  fetchHallOfFamePlayers: (...args) => fetchHallOfFamePlayers(...args),
+}));
+
+describe('HallOfFameView', () => {
+  it('fetches and displays players with sortable columns', async () => {
+    fetchHallOfFamePlayers.mockResolvedValue({
+      players: [
+        { bbref_id: 'b1', name: 'Alpha', mlbam_id: '1', year: 1990 },
+        { bbref_id: 'b2', name: 'Beta', mlbam_id: '2', year: 1980 },
+      ],
+    });
+
+    const { default: HallOfFameView } = await import('./HallOfFameView.vue');
+    const wrapper = mount(HallOfFameView);
+
+    await flushPromises();
+
+    const rows = wrapper.findAll('tbody tr');
+    expect(rows).toHaveLength(2);
+    expect(wrapper.html()).toContain('Alpha');
+
+    // sort by year
+    await wrapper.findAll('th')[2].trigger('click');
+    await flushPromises();
+    const sortedRows = wrapper.findAll('tbody tr');
+    expect(sortedRows[0].text()).toContain('Beta');
+
+    expect(sortedRows[0].html()).toContain('https://www.mlb.com/player/2');
+  });
+});
+

--- a/frontend/src/views/HallOfFameView.vue
+++ b/frontend/src/views/HallOfFameView.vue
@@ -1,15 +1,101 @@
 <template>
   <section class="hall-of-fame-view">
     <h1>Hall of Fame</h1>
+    <table v-if="players.length" class="hof-table">
+      <thead>
+        <tr>
+          <th @click="sortBy('name')">Player</th>
+          <th @click="sortBy('mlbam_id')">MLBAM ID</th>
+          <th @click="sortBy('year')">Year Inducted</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="player in sortedPlayers" :key="player.bbref_id">
+          <td>
+            <RouterLink
+              v-if="player.mlbam_id"
+              :to="{ name: 'Player', params: { id: player.mlbam_id }, query: { name: player.name } }"
+            >
+              {{ player.name || player.bbref_id }}
+            </RouterLink>
+            <span v-else>{{ player.name || player.bbref_id }}</span>
+          </td>
+          <td>
+            <a
+              v-if="player.mlbam_id"
+              :href="`https://www.mlb.com/player/${player.mlbam_id}`"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {{ player.mlbam_id }}
+            </a>
+          </td>
+          <td>{{ player.year }}</td>
+        </tr>
+      </tbody>
+    </table>
   </section>
 </template>
 
 <script setup>
-// Content will be added in future iterations
+import { ref, onMounted, computed } from 'vue';
+import { fetchHallOfFamePlayers } from '../services/api';
+import logger from '../utils/logger';
+
+const players = ref([]);
+const sortKey = ref('name');
+const sortAsc = ref(true);
+
+function sortBy(key) {
+  if (sortKey.value === key) {
+    sortAsc.value = !sortAsc.value;
+  } else {
+    sortKey.value = key;
+    sortAsc.value = true;
+  }
+}
+
+const sortedPlayers = computed(() => {
+  return [...players.value].sort((a, b) => {
+    const valA = a[sortKey.value] ?? '';
+    const valB = b[sortKey.value] ?? '';
+    if (valA < valB) return sortAsc.value ? -1 : 1;
+    if (valA > valB) return sortAsc.value ? 1 : -1;
+    return 0;
+  });
+});
+
+onMounted(async () => {
+  try {
+    const data = await fetchHallOfFamePlayers();
+    players.value = data?.players || [];
+  } catch (e) {
+    logger.error('Failed to fetch Hall of Fame players:', e);
+    players.value = [];
+  }
+});
 </script>
 
 <style scoped>
 .hall-of-fame-view {
   padding: 1rem;
 }
+
+.hof-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.hof-table th,
+.hof-table td {
+  padding: 0.5rem;
+  text-align: left;
+  border-bottom: 1px solid #ddd;
+}
+
+.hof-table th {
+  cursor: pointer;
+  background-color: #f5f5f5;
+}
 </style>
+


### PR DESCRIPTION
## Summary
- include player names and MLBAM IDs in Hall of Fame API
- display Hall of Fame players in sortable table with internal and MLB links
- test Hall of Fame view rendering and sorting

## Testing
- `pytest` *(fails: AssertionError / OperationalError)*
- `npm --prefix frontend test`

------
https://chatgpt.com/codex/tasks/task_e_68bdfee87db4832684f9bbf425b1d770