### PR TITLE
Add loading spinner to Hall of Fame view

### DIFF
--- a/frontend/src/views/HallOfFameView.test.js
+++ b/frontend/src/views/HallOfFameView.test.js
@@ -2,6 +2,12 @@
 import { describe, it, expect, vi } from 'vitest';
 import { mount, flushPromises } from '@vue/test-utils';
 
+const DialogStub = { props: ['visible'], template: '<div></div>' };
+const ProgressSpinnerStub = { template: '<div></div>' };
+
+vi.mock('primevue/dialog', () => ({ default: DialogStub }));
+vi.mock('primevue/progressspinner', () => ({ default: ProgressSpinnerStub }));
+
 const fetchHallOfFamePlayers = vi.fn();
 
 vi.mock('../services/api', () => ({
@@ -20,7 +26,13 @@ describe('HallOfFameView', () => {
     const { default: HallOfFameView } = await import('./HallOfFameView.vue');
     const wrapper = mount(HallOfFameView);
 
+    let dialog = wrapper.findComponent(DialogStub);
+    expect(dialog.props('visible')).toBe(true);
+
     await flushPromises();
+
+    dialog = wrapper.findComponent(DialogStub);
+    expect(dialog.props('visible')).toBe(false);
 
     const rows = wrapper.findAll('tbody tr');
     expect(rows).toHaveLength(2);

--- a/frontend/src/views/HallOfFameView.vue
+++ b/frontend/src/views/HallOfFameView.vue
@@ -34,6 +34,7 @@
         </tr>
       </tbody>
     </table>
+    <LoadingDialog :visible="loading" />
   </section>
 </template>
 
@@ -41,10 +42,12 @@
 import { ref, onMounted, computed } from 'vue';
 import { fetchHallOfFamePlayers } from '../services/api';
 import logger from '../utils/logger';
+import LoadingDialog from '../components/LoadingDialog.vue';
 
 const players = ref([]);
 const sortKey = ref('name');
 const sortAsc = ref(true);
+const loading = ref(true);
 
 function sortBy(key) {
   if (sortKey.value === key) {
@@ -72,6 +75,8 @@ onMounted(async () => {
   } catch (e) {
     logger.error('Failed to fetch Hall of Fame players:', e);
     players.value = [];
+  } finally {
+    loading.value = false;
   }
 });
 </script>


### PR DESCRIPTION
## Summary
- show LoadingDialog while Hall of Fame players load
- test loading dialog visibility in Hall of Fame view

## Testing
- `pytest` (fails: 16 failed)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be1947fc1c8326b555377b5973945a