### PR TITLE
Fix Hall of Fame mlbam_id formatting

### DIFF
--- a/frontend/src/views/HallOfFameView.test.js
+++ b/frontend/src/views/HallOfFameView.test.js
@@ -12,8 +12,8 @@ describe('HallOfFameView', () => {
   it('fetches and displays players with sortable columns', async () => {
     fetchHallOfFamePlayers.mockResolvedValue({
       players: [
-        { bbref_id: 'b1', name: 'Alpha', mlbam_id: '1', year: 1990 },
-        { bbref_id: 'b2', name: 'Beta', mlbam_id: '2', year: 1980 },
+        { bbref_id: 'b1', name: 'Alpha', mlbam_id: '1.0', year: 1990 },
+        { bbref_id: 'b2', name: 'Beta', mlbam_id: '2.0', year: 1980 },
       ],
     });
 
@@ -33,6 +33,7 @@ describe('HallOfFameView', () => {
     expect(sortedRows[0].text()).toContain('Beta');
 
     expect(sortedRows[0].html()).toContain('https://www.mlb.com/player/2');
+    expect(sortedRows[0].html()).not.toContain('2.0');
   });
 });
 

--- a/frontend/src/views/HallOfFameView.vue
+++ b/frontend/src/views/HallOfFameView.vue
@@ -68,7 +68,13 @@ const sortedPlayers = computed(() => {
 onMounted(async () => {
   try {
     const data = await fetchHallOfFamePlayers();
-    players.value = data?.players || [];
+    players.value = (data?.players || []).map((p) => {
+      const mlbam = Number.parseInt(p.mlbam_id, 10);
+      return {
+        ...p,
+        mlbam_id: Number.isNaN(mlbam) ? null : mlbam,
+      };
+    });
   } catch (e) {
     logger.error('Failed to fetch Hall of Fame players:', e);
     players.value = [];


### PR DESCRIPTION
## Summary
- Format Hall of Fame `mlbam_id` values as integers when displaying players
- Extend Hall of Fame view test to ensure IDs drop the `.0` suffix

## Testing
- `pytest` *(fails: OperationalError and other failures)*
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be26569e9c832698cae191c7d8d2ba