### PR TITLE
Hide game log tab without data

### DIFF
--- a/frontend/src/views/PlayerView.test.js
+++ b/frontend/src/views/PlayerView.test.js
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+
+// Stub components used by PlayerView
+const PlayerStatsStub = { template: '<div></div>' };
+const PlayerSplitsStub = { template: '<div></div>' };
+const PlayerGameLogStub = { template: '<div class="gamelog">Game Log Content</div>' };
+const LoadingDialogStub = { template: '<div></div>' };
+const TabViewStub = { template: '<div><slot></slot></div>' };
+const TabPanelStub = { template: '<div><slot></slot></div>' };
+
+vi.mock('../components/PlayerStats.vue', () => ({ default: PlayerStatsStub }));
+vi.mock('../components/PlayerSplits.vue', () => ({ default: PlayerSplitsStub }));
+vi.mock('../components/PlayerGameLog.vue', () => ({ default: PlayerGameLogStub }));
+vi.mock('../components/LoadingDialog.vue', () => ({ default: LoadingDialogStub }));
+vi.mock('primevue/tabview', () => ({ default: TabViewStub }));
+vi.mock('primevue/tabpanel', () => ({ default: TabPanelStub }));
+
+// Mock API calls
+const fetchPlayer = vi.fn();
+const fetchPlayerSplits = vi.fn();
+const fetchPlayerGameLog = vi.fn();
+
+vi.mock('../services/api.js', () => ({
+  fetchPlayer: (...args) => fetchPlayer(...args),
+  fetchPlayerSplits: (...args) => fetchPlayerSplits(...args),
+  fetchPlayerGameLog: (...args) => fetchPlayerGameLog(...args),
+}));
+
+describe('PlayerView game log tab', () => {
+  it('shows Game Log tab when data available', async () => {
+    fetchPlayer.mockResolvedValue({ name: 'Test', team_name: 'Team', position: 'Pitcher' });
+    fetchPlayerSplits.mockResolvedValue({});
+    fetchPlayerGameLog.mockResolvedValue({ stats: [{ splits: [{}] }] });
+
+    const { default: PlayerView } = await import('./PlayerView.vue');
+    const wrapper = mount(PlayerView, { props: { id: '1' } });
+    await flushPromises();
+
+    expect(wrapper.find('.gamelog').exists()).toBe(true);
+  });
+
+  it('hides Game Log tab when no data', async () => {
+    fetchPlayer.mockResolvedValue({ name: 'Test', team_name: 'Team', position: 'Pitcher' });
+    fetchPlayerSplits.mockResolvedValue({});
+    fetchPlayerGameLog.mockResolvedValue({ stats: [{ splits: [] }] });
+
+    const { default: PlayerView } = await import('./PlayerView.vue');
+    const wrapper = mount(PlayerView, { props: { id: '1' } });
+    await flushPromises();
+
+    expect(wrapper.find('.gamelog').exists()).toBe(false);
+  });
+});
+

--- a/frontend/src/views/PlayerView.vue
+++ b/frontend/src/views/PlayerView.vue
@@ -74,7 +74,7 @@
         <TabPanel v-if="splitsAvailable" header="Splits">
           <PlayerSplits :id="id" />
         </TabPanel>
-        <TabPanel header="Game Log">
+        <TabPanel v-if="gameLogAvailable" header="Game Log">
           <PlayerGameLog v-if="position" :id="id" :stat-type="statType" />
         </TabPanel>
         <TabPanel header="Charts & Trends">
@@ -95,7 +95,7 @@ import TabView from 'primevue/tabview';
 import TabPanel from 'primevue/tabpanel';
 import LoadingDialog from '../components/LoadingDialog.vue';
 import { useTeamColors } from '../composables/useTeamColors.js';
-import { fetchPlayer, fetchPlayerSplits } from '../services/api.js';
+import { fetchPlayer, fetchPlayerSplits, fetchPlayerGameLog } from '../services/api.js';
 
 const { id } = defineProps({
   id: String
@@ -117,6 +117,7 @@ const draft = ref(null);
 const mlbDebutDate = ref('');
 const loading = ref(true);
 const splitsAvailable = ref(false);
+const gameLogAvailable = ref(false);
 
 const statType = computed(() => (position.value === 'Pitcher' ? 'pitching' : 'hitting'));
 
@@ -197,6 +198,12 @@ onMounted(async () => {
         splits.monthly?.pitching?.length
       )
     );
+
+    if (position.value) {
+      const season = new Date().getFullYear();
+      const gameLog = await fetchPlayerGameLog(id, statType.value, season);
+      gameLogAvailable.value = Boolean(gameLog?.stats?.[0]?.splits?.length);
+    }
   } finally {
     loading.value = false;
   }


### PR DESCRIPTION
## Summary
- fetch player game log data to determine availability
- display Game Log tab only when game log data exists
- add tests ensuring the Game Log tab shows or hides appropriately

## Testing
- `npm test --prefix frontend`
- `pytest` *(fails: no such table and DisallowedHost errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bf39afc70483269fd6f165c8c769ff