### PR TITLE
Sort Hall of Fame by last name

### DIFF
--- a/frontend/src/views/HallOfFameView.test.js
+++ b/frontend/src/views/HallOfFameView.test.js
@@ -19,20 +19,20 @@ describe('HallOfFameView', () => {
     fetchHallOfFamePlayers.mockResolvedValue({
       players: [
         {
-          bbref_id: 'b1',
-          name: 'Alpha One',
-          first_name: 'Alpha',
-          last_name: 'One',
-          mlbam_id: '1',
-          year: 1990,
-        },
-        {
           bbref_id: 'b2',
           name: 'Beta Two',
           first_name: 'Beta',
           last_name: 'Two',
           mlbam_id: '2',
           year: 1980,
+        },
+        {
+          bbref_id: 'b1',
+          name: 'Alpha One',
+          first_name: 'Alpha',
+          last_name: 'One',
+          mlbam_id: '1',
+          year: 1990,
         },
       ],
     });

--- a/frontend/src/views/HallOfFameView.vue
+++ b/frontend/src/views/HallOfFameView.vue
@@ -49,7 +49,7 @@ import logger from '../utils/logger';
 import LoadingDialog from '../components/LoadingDialog.vue';
 
 const players = ref([]);
-const sortKey = ref('name');
+const sortKey = ref('last_name');
 const sortAsc = ref(true);
 const loading = ref(true);
 


### PR DESCRIPTION
## Summary
- Default Hall of Fame table sorting now uses each player's `last_name`
- Adjust Hall of Fame tests to ensure players are ordered by last name on load

## Testing
- `npm --prefix frontend test`
- `pytest` *(fails: no such table: player_id_infos)*

------
https://chatgpt.com/codex/tasks/task_e_68bf42da1108832683b082c53694bb82