### PR TITLE
Fix Hall of Fame year sorting

### DIFF
--- a/frontend/src/views/HallOfFameView.test.js
+++ b/frontend/src/views/HallOfFameView.test.js
@@ -63,5 +63,42 @@ describe('HallOfFameView', () => {
     expect(sortedRows[0].html()).toContain('https://www.mlb.com/player/2');
     expect(sortedRows[0].html()).not.toContain('2.0');
   });
+
+  it('sorts years numerically when reversing sort order', async () => {
+    fetchHallOfFamePlayers.mockResolvedValue({
+      players: [
+        {
+          bbref_id: 'm1',
+          name: 'Minnie Minoso',
+          first_name: 'Minnie',
+          last_name: 'Minoso',
+          mlbam_id: '3',
+          year: '2022',
+        },
+        {
+          bbref_id: 'f1',
+          name: 'Future Star',
+          first_name: 'Future',
+          last_name: 'Star',
+          mlbam_id: '4',
+          year: '2025',
+        },
+      ],
+    });
+
+    const { default: HallOfFameView } = await import('./HallOfFameView.vue');
+    const wrapper = mount(HallOfFameView);
+
+    await flushPromises();
+
+    const yearHeader = wrapper.findAll('th')[4];
+    await yearHeader.trigger('click');
+    await flushPromises();
+    await yearHeader.trigger('click');
+    await flushPromises();
+
+    const rows = wrapper.findAll('tbody tr');
+    expect(rows[0].text()).toContain('Future Star');
+  });
 });
 

--- a/frontend/src/views/HallOfFameView.vue
+++ b/frontend/src/views/HallOfFameView.vue
@@ -64,8 +64,17 @@ function sortBy(key) {
 
 const sortedPlayers = computed(() => {
   return [...players.value].sort((a, b) => {
-    const valA = a[sortKey.value] ?? '';
-    const valB = b[sortKey.value] ?? '';
+    let valA = a[sortKey.value];
+    let valB = b[sortKey.value];
+
+    if (sortKey.value === 'year' || sortKey.value === 'mlbam_id') {
+      valA = Number(valA) || 0;
+      valB = Number(valB) || 0;
+    } else {
+      valA = valA ?? '';
+      valB = valB ?? '';
+    }
+
     if (valA < valB) return sortAsc.value ? -1 : 1;
     if (valA > valB) return sortAsc.value ? 1 : -1;
     return 0;
@@ -77,9 +86,11 @@ onMounted(async () => {
     const data = await fetchHallOfFamePlayers();
     players.value = (data?.players || []).map((p) => {
       const mlbam = Number.parseInt(p.mlbam_id, 10);
+      const year = Number.parseInt(p.year, 10);
       return {
         ...p,
         mlbam_id: Number.isNaN(mlbam) ? null : mlbam,
+        year: Number.isNaN(year) ? null : year,
       };
     });
   } catch (e) {


### PR DESCRIPTION
## Summary
- ensure numeric sorting for Hall of Fame year and MLBAM ID
- convert year to a number when loading Hall of Fame data
- add regression test for year sorting

## Testing
- `npm test`
- `pytest` *(fails: django.db.utils.OperationalError: no such table: teams_team)*

------
https://chatgpt.com/codex/tasks/task_e_68bf43aa92c88326b9b3cacc6b553bd5