### PR TITLE
Show team names in player search suggestions

### DIFF
--- a/backend/apps/api/serializers.py
+++ b/backend/apps/api/serializers.py
@@ -9,6 +9,7 @@ class PlayerSearchResultSerializer(serializers.Serializer):
     id = serializers.IntegerField()
     name_full = serializers.CharField()
     key_mlbam = serializers.CharField(allow_null=True)
+    team_name = serializers.CharField(allow_null=True)
 
 
 class DraftInfoSerializer(serializers.Serializer):

--- a/frontend/src/components/SearchAutocomplete.vue
+++ b/frontend/src/components/SearchAutocomplete.vue
@@ -8,7 +8,10 @@
     :placeholder="placeholder"
   >
     <template #option="{ option }">
-      <div>{{ option[optionLabel] }}</div>
+      <div>
+        {{ option[optionLabel] }}
+        <span v-if="option.team_name"> - {{ option.team_name }}</span>
+      </div>
     </template>
   </AutoComplete>
 </template>


### PR DESCRIPTION
## Summary
- include team name in player search API results
- show player team name in search autocomplete options

## Testing
- `pytest` *(fails: OperationalError: no such table: player_id_infos)*
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf605baec08326b6e117d9903d6ef3