### PR TITLE
feat: cache Hall of Fame data in localStorage

### DIFF
--- a/frontend/src/views/HallOfFameView.vue
+++ b/frontend/src/views/HallOfFameView.vue
@@ -68,6 +68,7 @@ import LoadingDialog from '../components/LoadingDialog.vue';
 import Paginator from 'primevue/paginator';
 
 const players = ref([]);
+const HOF_CACHE_TTL = 24 * 60 * 60 * 1000;
 const sortKey = ref('last_name');
 const sortAsc = ref(true);
 const loading = ref(true);
@@ -158,7 +159,7 @@ const paginatedPlayers = computed(() => {
 
 onMounted(async () => {
   try {
-    const data = await fetchHallOfFamePlayers();
+    const data = await fetchHallOfFamePlayers({ persistTTL: HOF_CACHE_TTL });
     players.value = (data?.players || []).map((p) => {
       const mlbam = Number.parseInt(p.mlbam_id, 10);
       const year = Number.parseInt(p.year, 10);


### PR DESCRIPTION
## Summary
- persist API responses in localStorage with TTL
- cache Hall of Fame players between sessions

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfa974b4448326b3217a3f9e9d1674