### PR TITLE
Add batter spray chart for player page

### DIFF
--- a/frontend/src/components.d.ts
+++ b/frontend/src/components.d.ts
@@ -8,6 +8,7 @@ export {}
 /* prettier-ignore */
 declare module 'vue' {
   export interface GlobalComponents {
+    BatterSprayChart: typeof import('./components/BatterSprayChart.vue')['default']
     Column: typeof import('primevue/column')['default']
     DataTable: typeof import('primevue/datatable')['default']
     GameRow: typeof import('./components/GameRow.vue')['default']

--- a/frontend/src/components/BatterSprayChart.vue
+++ b/frontend/src/components/BatterSprayChart.vue
@@ -1,0 +1,69 @@
+<template>
+  <div class="batter-spray-chart">
+    <canvas ref="canvasEl"></canvas>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, onBeforeUnmount } from 'vue';
+import Chart from 'chart.js/auto';
+
+const canvasEl = ref(null);
+let chartInstance;
+
+// Dummy spray chart data points
+const sprayData = [
+  { x: -30, y: 80 },
+  { x: 20, y: 70 },
+  { x: -60, y: 110 },
+  { x: 50, y: 90 },
+  { x: 0, y: 120 }
+];
+
+onMounted(() => {
+  if (canvasEl.value) {
+    chartInstance = new Chart(canvasEl.value, {
+      type: 'scatter',
+      data: {
+        datasets: [
+          {
+            label: 'Spray Chart',
+            data: sprayData,
+            backgroundColor: 'rgba(75, 192, 192, 1)'
+          }
+        ]
+      },
+      options: {
+        maintainAspectRatio: false,
+        scales: {
+          x: {
+            min: -150,
+            max: 150
+          },
+          y: {
+            min: 0,
+            max: 150
+          }
+        }
+      }
+    });
+  }
+});
+
+onBeforeUnmount(() => {
+  if (chartInstance) {
+    chartInstance.destroy();
+  }
+});
+</script>
+
+<style scoped>
+.batter-spray-chart {
+  position: relative;
+  width: 100%;
+  max-width: 500px;
+  height: 400px;
+  margin: 0 auto;
+}
+</style>
+

--- a/frontend/src/views/PlayerView.test.js
+++ b/frontend/src/views/PlayerView.test.js
@@ -9,11 +9,13 @@ const PlayerGameLogStub = { template: '<div class="gamelog">Game Log Content</di
 const LoadingDialogStub = { template: '<div></div>' };
 const TabViewStub = { template: '<div><slot></slot></div>' };
 const TabPanelStub = { template: '<div><slot></slot></div>' };
+const BatterSprayChartStub = { template: '<div class="spray-chart"></div>' };
 
 vi.mock('../components/PlayerStats.vue', () => ({ default: PlayerStatsStub }));
 vi.mock('../components/PlayerSplits.vue', () => ({ default: PlayerSplitsStub }));
 vi.mock('../components/PlayerGameLog.vue', () => ({ default: PlayerGameLogStub }));
 vi.mock('../components/LoadingDialog.vue', () => ({ default: LoadingDialogStub }));
+vi.mock('../components/BatterSprayChart.vue', () => ({ default: BatterSprayChartStub }));
 vi.mock('primevue/tabview', () => ({ default: TabViewStub }));
 vi.mock('primevue/tabpanel', () => ({ default: TabPanelStub }));
 
@@ -51,6 +53,18 @@ describe('PlayerView game log tab', () => {
     await flushPromises();
 
     expect(wrapper.find('.gamelog').exists()).toBe(false);
+  });
+
+  it('shows spray chart for batters', async () => {
+    fetchPlayer.mockResolvedValue({ name: 'Test', team_name: 'Team', position: 'Catcher' });
+    fetchPlayerSplits.mockResolvedValue({});
+    fetchPlayerGameLog.mockResolvedValue({ stats: [{ splits: [] }] });
+
+    const { default: PlayerView } = await import('./PlayerView.vue');
+    const wrapper = mount(PlayerView, { props: { id: '1' } });
+    await flushPromises();
+
+    expect(wrapper.find('.spray-chart').exists()).toBe(true);
   });
 });
 

--- a/frontend/src/views/PlayerView.vue
+++ b/frontend/src/views/PlayerView.vue
@@ -78,7 +78,8 @@
           <PlayerGameLog v-if="position" :id="id" :stat-type="statType" />
         </TabPanel>
         <TabPanel header="Charts & Trends">
-          <p>Charts & Trends coming soon.</p>
+          <BatterSprayChart v-if="statType === 'hitting'" />
+          <p v-else>Charts & Trends coming soon.</p>
         </TabPanel>
       </TabView>
     </div>
@@ -91,6 +92,7 @@ import { ref, computed, onMounted } from 'vue';
 import PlayerStats from '../components/PlayerStats.vue';
 import PlayerSplits from '../components/PlayerSplits.vue';
 import PlayerGameLog from '../components/PlayerGameLog.vue';
+import BatterSprayChart from '../components/BatterSprayChart.vue';
 import TabView from 'primevue/tabview';
 import TabPanel from 'primevue/tabpanel';
 import LoadingDialog from '../components/LoadingDialog.vue';


### PR DESCRIPTION
## Summary
- show batter spray chart in Charts & Trends tab
- create BatterSprayChart component with dummy data
- test PlayerView renders spray chart for hitters

## Testing
- `npm test`
- `pytest` *(fails: no such table: player_id_infos)*

------
https://chatgpt.com/codex/tasks/task_e_68bfaad781b883269935616547294b7b