### PR TITLE
feat: add reports tab to player page

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -55,6 +55,12 @@ const routes = [
     props: route => ({ id: route.params.id, name: route.query.name })
   },
   {
+    path: '/player/:id/reports',
+    name: 'PlayerReports',
+    component: () => import('../views/ReportsView.vue'),
+    props: route => ({ id: route.params.id })
+  },
+  {
     path: '/developer',
     name: 'ApiExplorer',
     component: () => import('../views/ApiExplorerView.vue')

--- a/frontend/src/views/PlayerView.test.js
+++ b/frontend/src/views/PlayerView.test.js
@@ -10,6 +10,7 @@ const LoadingDialogStub = { template: '<div></div>' };
 const TabViewStub = { template: '<div><slot></slot></div>' };
 const TabPanelStub = { template: '<div><slot></slot></div>' };
 const BatterSprayChartStub = { template: '<div class="spray-chart"></div>' };
+const RouterLinkStub = { template: '<a><slot></slot></a>' };
 
 vi.mock('../components/PlayerStats.vue', () => ({ default: PlayerStatsStub }));
 vi.mock('../components/PlayerSplits.vue', () => ({ default: PlayerSplitsStub }));
@@ -18,6 +19,7 @@ vi.mock('../components/LoadingDialog.vue', () => ({ default: LoadingDialogStub }
 vi.mock('../components/BatterSprayChart.vue', () => ({ default: BatterSprayChartStub }));
 vi.mock('primevue/tabview', () => ({ default: TabViewStub }));
 vi.mock('primevue/tabpanel', () => ({ default: TabPanelStub }));
+vi.mock('vue-router', () => ({ RouterLink: RouterLinkStub }));
 
 // Mock API calls
 const fetchPlayer = vi.fn();

--- a/frontend/src/views/PlayerView.vue
+++ b/frontend/src/views/PlayerView.vue
@@ -81,6 +81,11 @@
           <BatterSprayChart v-if="statType === 'hitting'" />
           <p v-else>Charts & Trends coming soon.</p>
         </TabPanel>
+        <TabPanel>
+          <template #header>
+            <RouterLink :to="{ name: 'PlayerReports', params: { id } }">Reports</RouterLink>
+          </template>
+        </TabPanel>
       </TabView>
     </div>
     <LoadingDialog :visible="loading" />
@@ -89,6 +94,7 @@
 
 <script setup>
 import { ref, computed, onMounted } from 'vue';
+import { RouterLink } from 'vue-router';
 import PlayerStats from '../components/PlayerStats.vue';
 import PlayerSplits from '../components/PlayerSplits.vue';
 import PlayerGameLog from '../components/PlayerGameLog.vue';

--- a/frontend/src/views/ReportsView.vue
+++ b/frontend/src/views/ReportsView.vue
@@ -1,0 +1,20 @@
+<template>
+  <section class="reports-view">
+    <h1>Reports</h1>
+    <p>Reports coming soon.</p>
+  </section>
+</template>
+
+<script setup>
+const { id } = defineProps({
+  id: String
+});
+</script>
+
+<style scoped>
+.reports-view {
+  padding: 1rem;
+  text-align: left;
+}
+</style>
+


### PR DESCRIPTION
## Summary
- add a Reports tab to PlayerView that links to PlayerReports route
- define PlayerReports route and placeholder ReportsView
- update PlayerView tests to stub RouterLink

## Testing
- `npm test`
- `pytest` *(fails: OperationalError: no such table: scoreboard_game)*

------
https://chatgpt.com/codex/tasks/task_e_68bfacb2698c8326a5f4c7bfdff36d73