### PR TITLE
Add utility for calculating player age

### DIFF
--- a/frontend/src/utils/calculateAge.js
+++ b/frontend/src/utils/calculateAge.js
@@ -1,0 +1,22 @@
+/**
+ * Calculate current age in full years based on a birthdate.
+ *
+ * @param {string|Date} birthDate - Date of birth as a Date object or parseable string.
+ * @returns {number|null} Age in years, or null if the date is invalid/missing.
+ */
+export function calculateAge(birthDate) {
+  if (!birthDate) return null;
+  const date = birthDate instanceof Date ? birthDate : new Date(birthDate);
+  if (isNaN(date.getTime())) return null;
+
+  const today = new Date();
+  let age = today.getFullYear() - date.getFullYear();
+  const monthDiff = today.getMonth() - date.getMonth();
+  const dayDiff = today.getDate() - date.getDate();
+  if (monthDiff < 0 || (monthDiff === 0 && dayDiff < 0)) {
+    age--;
+  }
+  return age;
+}
+
+export default calculateAge;

--- a/frontend/src/utils/calculateAge.test.js
+++ b/frontend/src/utils/calculateAge.test.js
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from 'vitest';
+import calculateAge from './calculateAge.js';
+
+describe('calculateAge', () => {
+  it('computes age based on current date', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-05-01'));
+    expect(calculateAge('2000-06-15')).toBe(23);
+    expect(calculateAge('2000-04-15')).toBe(24);
+    vi.useRealTimers();
+  });
+
+  it('returns null for invalid or missing date', () => {
+    expect(calculateAge('invalid')).toBeNull();
+    expect(calculateAge()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add `calculateAge` utility to compute a player's current age from birthdate
- cover new helper with vitest unit tests

## Testing
- `npm test`
- `pytest` *(fails: OperationalError: no such table: player_id_infos)*

------
https://chatgpt.com/codex/tasks/task_e_68c03729b1e883268aa01a375194a2e9