### PR TITLE
Add last name search to Hall of Fame view

### DIFF
--- a/frontend/src/views/HallOfFameView.test.js
+++ b/frontend/src/views/HallOfFameView.test.js
@@ -282,6 +282,45 @@ describe('HallOfFameView', () => {
     expect(rows[0].text()).toContain('First50');
   });
 
+  it('filters players by last name across all pages', async () => {
+    const players = Array.from({ length: 60 }, (_, i) => ({
+      bbref_id: `id${i}`,
+      name: `Player ${i}`,
+      first_name: `First${i}`,
+      last_name: `Last${i}`,
+      position: 'Pitcher',
+      mlbam_id: String(i),
+      year: 2000 + i,
+    }));
+    fetchHallOfFamePlayers.mockResolvedValue({ players });
+
+    const { default: HallOfFameView } = await import('./HallOfFameView.vue');
+    const wrapper = mount(HallOfFameView);
+
+    await flushPromises();
+
+    const input = wrapper.find('[data-test="last-name-search"]');
+    await input.setValue('Last55');
+    await flushPromises();
+    let rows = wrapper.findAll('tbody tr');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].text()).toContain('First55');
+
+    await input.setValue('');
+    await flushPromises();
+
+    const paginator = wrapper.findComponent(PaginatorStub);
+    paginator.vm.$emit('page', { first: 50, rows: 50 });
+    await flushPromises();
+    expect(wrapper.findAll('tbody tr')[0].text()).toContain('First50');
+
+    await input.setValue('Last0');
+    await flushPromises();
+    rows = wrapper.findAll('tbody tr');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].text()).toContain('First0');
+  });
+
   it('applies sorting and filtering across all pages', async () => {
     const players = Array.from({ length: 60 }, (_, i) => ({
       bbref_id: `id${i}`,

--- a/frontend/src/views/HallOfFameView.vue
+++ b/frontend/src/views/HallOfFameView.vue
@@ -12,7 +12,14 @@
         </tr>
         <tr class="filters">
           <th></th>
-          <th></th>
+          <th>
+            <input
+              v-model="lastNameSearch"
+              type="text"
+              placeholder="Search"
+              data-test="last-name-search"
+            />
+          </th>
           <th>
             <select v-model="positionFilter" data-test="position-filter">
               <option value="">All</option>
@@ -74,10 +81,11 @@ const sortAsc = ref(true);
 const loading = ref(true);
 const positionFilter = ref('');
 const yearFilter = ref('');
+const lastNameSearch = ref('');
 const first = ref(0);
 const rows = 50;
 
-watch([sortKey, sortAsc, positionFilter, yearFilter], () => {
+watch([sortKey, sortAsc, positionFilter, yearFilter, lastNameSearch], () => {
   first.value = 0;
 });
 
@@ -117,7 +125,9 @@ const filteredPlayers = computed(() =>
   players.value.filter(
     (p) =>
       (!positionFilter.value || p.position === positionFilter.value) &&
-      (!yearFilter.value || p.year === Number(yearFilter.value))
+      (!yearFilter.value || p.year === Number(yearFilter.value)) &&
+      (!lastNameSearch.value ||
+        (p.last_name ?? '').toLowerCase().includes(lastNameSearch.value.toLowerCase()))
   )
 );
 
@@ -205,6 +215,10 @@ onMounted(async () => {
 }
 
 .filters select {
+  width: 100%;
+}
+
+.filters input {
   width: 100%;
 }
 </style>


### PR DESCRIPTION
## Summary
- Add search input for last names on Hall of Fame page
- Filter players by last name across all pages with new tests

## Testing
- `npm test`
- `pytest` *(fails: OperationalError / 400 responses)*

------
https://chatgpt.com/codex/tasks/task_e_68c037eddb208326ae1b697860ea8c68