### PR TITLE
feat: add tab panels to hall of fame view

### DIFF
--- a/frontend/src/views/HallOfFameView.test.js
+++ b/frontend/src/views/HallOfFameView.test.js
@@ -9,10 +9,14 @@ const PaginatorStub = {
   emits: ['page'],
   template: '<div></div>',
 };
+const TabViewStub = { template: '<div><slot></slot></div>' };
+const TabPanelStub = { template: '<div><slot></slot></div>' };
 
 vi.mock('primevue/dialog', () => ({ default: DialogStub }));
 vi.mock('primevue/progressspinner', () => ({ default: ProgressSpinnerStub }));
 vi.mock('primevue/paginator', () => ({ default: PaginatorStub }));
+vi.mock('primevue/tabview', () => ({ default: TabViewStub }));
+vi.mock('primevue/tabpanel', () => ({ default: TabPanelStub }));
 
 const fetchHallOfFamePlayers = vi.fn();
 

--- a/frontend/src/views/HallOfFameView.vue
+++ b/frontend/src/views/HallOfFameView.vue
@@ -1,68 +1,75 @@
 <template>
   <section class="hall-of-fame-view">
     <h1>Hall of Fame</h1>
-    <table v-if="players.length" class="hof-table">
-      <thead>
-        <tr>
-          <th @click="sortBy('first_name')">First Name</th>
-          <th @click="sortBy('last_name')">Last Name</th>
-          <th @click="sortBy('position')">Position</th>
-          <th @click="sortBy('mlbam_id')">MLBAM ID</th>
-          <th @click="sortBy('year')">Year Inducted</th>
-        </tr>
-        <tr class="filters">
-          <th></th>
-          <th>
-            <input
-              v-model="lastNameSearch"
-              type="text"
-              placeholder="Search"
-              data-test="last-name-search"
-            />
-          </th>
-          <th>
-            <select v-model="positionFilter" data-test="position-filter">
-              <option value="">All</option>
-              <option v-for="pos in positions" :key="pos" :value="pos">
-                {{ pos }}
-              </option>
-            </select>
-          </th>
-          <th></th>
-          <th>
-            <select v-model="yearFilter" data-test="year-filter">
-              <option value="">All</option>
-              <option v-for="y in years" :key="y" :value="y">{{ y }}</option>
-            </select>
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr v-for="player in paginatedPlayers" :key="player.bbref_id">
-          <td>{{ player.first_name }}</td>
-          <td>{{ player.last_name }}</td>
-          <td>{{ player.position }}</td>
-          <td>
-            <a
-              v-if="player.mlbam_id"
-              :href="`https://www.mlb.com/player/${player.mlbam_id}`"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {{ player.mlbam_id }}
-            </a>
-          </td>
-          <td>{{ player.year }}</td>
-        </tr>
-      </tbody>
-    </table>
-    <Paginator
-      v-if="sortedPlayers.length > rows"
-      :first="first"
-      :rows="rows"
-      :totalRecords="sortedPlayers.length"
-      @page="onPage"
-    />
+    <TabView>
+      <TabPanel header="Inductees">
+        <table v-if="players.length" class="hof-table">
+          <thead>
+            <tr>
+              <th @click="sortBy('first_name')">First Name</th>
+              <th @click="sortBy('last_name')">Last Name</th>
+              <th @click="sortBy('position')">Position</th>
+              <th @click="sortBy('mlbam_id')">MLBAM ID</th>
+              <th @click="sortBy('year')">Year Inducted</th>
+            </tr>
+            <tr class="filters">
+              <th></th>
+              <th>
+                <input
+                  v-model="lastNameSearch"
+                  type="text"
+                  placeholder="Search"
+                  data-test="last-name-search"
+                />
+              </th>
+              <th>
+                <select v-model="positionFilter" data-test="position-filter">
+                  <option value="">All</option>
+                  <option v-for="pos in positions" :key="pos" :value="pos">
+                    {{ pos }}
+                  </option>
+                </select>
+              </th>
+              <th></th>
+              <th>
+                <select v-model="yearFilter" data-test="year-filter">
+                  <option value="">All</option>
+                  <option v-for="y in years" :key="y" :value="y">{{ y }}</option>
+                </select>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="player in paginatedPlayers" :key="player.bbref_id">
+              <td>{{ player.first_name }}</td>
+              <td>{{ player.last_name }}</td>
+              <td>{{ player.position }}</td>
+              <td>
+                <a
+                  v-if="player.mlbam_id"
+                  :href="`https://www.mlb.com/player/${player.mlbam_id}`"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {{ player.mlbam_id }}
+                </a>
+              </td>
+              <td>{{ player.year }}</td>
+            </tr>
+          </tbody>
+        </table>
+        <Paginator
+          v-if="sortedPlayers.length > rows"
+          :first="first"
+          :rows="rows"
+          :totalRecords="sortedPlayers.length"
+          @page="onPage"
+        />
+      </TabPanel>
+      <TabPanel header="Career Stats">
+        <!-- Career Stats content coming soon -->
+      </TabPanel>
+    </TabView>
     <LoadingDialog :visible="loading" />
   </section>
 </template>
@@ -73,6 +80,8 @@ import { fetchHallOfFamePlayers } from '../services/api';
 import logger from '../utils/logger';
 import LoadingDialog from '../components/LoadingDialog.vue';
 import Paginator from 'primevue/paginator';
+import TabView from 'primevue/tabview';
+import TabPanel from 'primevue/tabpanel';
 
 const players = ref([]);
 const HOF_CACHE_TTL = 24 * 60 * 60 * 1000;


### PR DESCRIPTION
## Summary
- add primevue tabview to Hall of Fame page with Inductees and Career Stats tabs
- stub TabView and TabPanel in HallOfFameView tests

## Testing
- `npm test`
- `pytest` *(fails: backend tests require database)*

------
https://chatgpt.com/codex/tasks/task_e_68c0396524dc8326b824c63a8e7d1757