### PR TITLE
Add dual batter spray charts with diamond background

### DIFF
--- a/frontend/src/assets/diamond.svg
+++ b/frontend/src/assets/diamond.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 300">
+  <polygon points="150,20 280,150 150,280 20,150" fill="none" stroke="#d3d3d3" stroke-width="2" />
+  <polygon points="150,100 200,150 150,200 100,150" fill="none" stroke="#d3d3d3" stroke-width="1" />
+</svg>


### PR DESCRIPTION
## Summary
- Display batted ball and hit spray charts on Player page
- Overlay charts on a baseball diamond background with color-coded outcomes

## Testing
- `npm test`
- `pytest` *(fails: no such table: player_id_infos and disallowed host 'testserver')*

------
https://chatgpt.com/codex/tasks/task_e_68c03a6b47d4832682a4668c84c3e45a