### PR TITLE
Add career stats tables to Hall of Fame page

### DIFF
--- a/frontend/src/views/HallOfFameView.vue
+++ b/frontend/src/views/HallOfFameView.vue
@@ -9,9 +9,9 @@
               <th @click="sortBy('first_name')">First Name</th>
               <th @click="sortBy('last_name')">Last Name</th>
               <th @click="sortBy('position')">Position</th>
+              <th @click="sortBy('mlbam_id')">MLBAM ID</th>
               <th @click="sortBy('year')">Year Inducted</th>
               <th @click="sortBy('voted_by')">Voted By</th>
-              <th @click="sortBy('mlbam_id')">MLBAM ID</th>
             </tr>
             <tr class="filters">
               <th></th>
@@ -31,6 +31,7 @@
                   </option>
                 </select>
               </th>
+              <th></th>
               <th>
                 <select v-model="yearFilter" data-test="year-filter">
                   <option value="">All</option>
@@ -45,7 +46,6 @@
               <td>{{ player.first_name }}</td>
               <td>{{ player.last_name }}</td>
               <td>{{ player.position }}</td>
-              <td>{{ player.year }}</td>
               <td>
                 <a
                   v-if="player.mlbam_id"
@@ -56,6 +56,7 @@
                   {{ player.mlbam_id }}
                 </a>
               </td>
+              <td>{{ player.year }}</td>
               <td>{{ player.voted_by }}</td>
             </tr>
           </tbody>
@@ -69,7 +70,40 @@
         />
       </TabPanel>
       <TabPanel header="Career Stats">
-        <!-- Career Stats content coming soon -->
+        <div v-if="hitters.length">
+          <h2>Hitters</h2>
+          <table class="hof-table">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th v-for="field in hittingFields" :key="field">{{ fieldLabels[field] ?? field }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="h in hitters" :key="h.name">
+                <td>{{ h.name }}</td>
+                <td v-for="field in hittingFields" :key="field">{{ h[field] ?? '-' }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div v-if="pitchers.length">
+          <h2>Pitchers</h2>
+          <table class="hof-table">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th v-for="field in pitchingFields" :key="field">{{ fieldLabels[field] ?? field }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="p in pitchers" :key="p.name">
+                <td>{{ p.name }}</td>
+                <td v-for="field in pitchingFields" :key="field">{{ p[field] ?? '-' }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </TabPanel>
     </TabView>
     <LoadingDialog :visible="loading" />
@@ -78,7 +112,8 @@
 
 <script setup>
 import { ref, onMounted, computed, watch } from 'vue';
-import { fetchHallOfFamePlayers } from '../services/api';
+import { fetchHallOfFamePlayers, fetchPlayerStats } from '../services/api';
+import { fieldLabels } from '../config/playerStatsConfig.js';
 import logger from '../utils/logger';
 import LoadingDialog from '../components/LoadingDialog.vue';
 import Paginator from 'primevue/paginator';
@@ -86,6 +121,8 @@ import TabView from 'primevue/tabview';
 import TabPanel from 'primevue/tabpanel';
 
 const players = ref([]);
+const hitters = ref([]);
+const pitchers = ref([]);
 const HOF_CACHE_TTL = 24 * 60 * 60 * 1000;
 const sortKey = ref('last_name');
 const sortAsc = ref(true);
@@ -95,6 +132,9 @@ const yearFilter = ref('');
 const lastNameSearch = ref('');
 const first = ref(0);
 const rows = 50;
+
+const hittingFields = ['atBats', 'hits', 'homeRuns', 'rbi', 'avg', 'obp', 'slg', 'ops'];
+const pitchingFields = ['wins', 'losses', 'era', 'gamesPitched', 'gamesStarted', 'inningsPitched', 'strikeOuts', 'saves', 'whip'];
 
 watch([sortKey, sortAsc, positionFilter, yearFilter, lastNameSearch], () => {
   first.value = 0;
@@ -178,6 +218,32 @@ const paginatedPlayers = computed(() => {
   return sortedPlayers.value.slice(start, start + rows);
 });
 
+function findGroup(data, name, type) {
+  return data?.stats?.find(
+    (s) => s.group?.displayName === name && s.type?.displayName === type,
+  );
+}
+
+async function loadCareerStats() {
+  const hit = [];
+  const pitch = [];
+  for (const p of players.value) {
+    if (!p.mlbam_id) continue;
+    try {
+      const stats = await fetchPlayerStats(p.mlbam_id);
+      const name = `${p.first_name ?? ''} ${p.last_name ?? ''}`.trim() || p.name;
+      const h = findGroup(stats, 'hitting', 'career')?.splits?.[0]?.stat;
+      const pc = findGroup(stats, 'pitching', 'career')?.splits?.[0]?.stat;
+      if (h) hit.push({ name, ...h });
+      if (pc) pitch.push({ name, ...pc });
+    } catch (err) {
+      logger.error('Failed to fetch stats for player', p.mlbam_id, err);
+    }
+  }
+  hitters.value = hit.sort((a, b) => collator.compare(a.name, b.name));
+  pitchers.value = pitch.sort((a, b) => collator.compare(a.name, b.name));
+}
+
 onMounted(async () => {
   try {
     const data = await fetchHallOfFamePlayers({ persistTTL: HOF_CACHE_TTL });
@@ -190,6 +256,7 @@ onMounted(async () => {
         year: Number.isNaN(year) ? null : year,
       };
     });
+    await loadCareerStats();
   } catch (e) {
     logger.error('Failed to fetch Hall of Fame players:', e);
     players.value = [];


### PR DESCRIPTION
## Summary
- show career totals tables for Hall of Fame hitters and pitchers
- fetch and display MLB career stats for inductees

## Testing
- `npm test`
- `pytest` *(fails: OperationalError: no such table and other 400 responses)*

------
https://chatgpt.com/codex/tasks/task_e_68c06039b03c8326a27b155de4d169c0