### PR TITLE
Show inductee count on Hall of Fame page

### DIFF
--- a/frontend/src/views/HallOfFameView.test.js
+++ b/frontend/src/views/HallOfFameView.test.js
@@ -65,6 +65,9 @@ describe('HallOfFameView', () => {
     dialog = wrapper.findComponent(DialogStub);
     expect(dialog.props('visible')).toBe(false);
 
+    const count = wrapper.find('[data-test="inductee-count"]');
+    expect(count.text()).toBe('2 Inductees');
+
     const rows = wrapper.findAll('tbody tr');
     expect(rows).toHaveLength(2);
     const cells = rows[0].findAll('td');

--- a/frontend/src/views/HallOfFameView.vue
+++ b/frontend/src/views/HallOfFameView.vue
@@ -3,6 +3,9 @@
     <h1>Hall of Fame</h1>
     <TabView>
       <TabPanel header="Inductees">
+        <p v-if="!loading" data-test="inductee-count">
+          {{ players.length }} Inductees
+        </p>
         <table v-if="players.length" class="hof-table">
           <thead>
             <tr>


### PR DESCRIPTION
## Summary
- display total number of Hall of Fame inductees above the table
- test Hall of Fame view shows inductee count

## Testing
- `npm test`
- `pytest` *(fails: database not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68c07233e4a48326937762944c411209