### PR TITLE
feat: separate hitting and pitching tabs

### DIFF
--- a/frontend/src/views/HallOfFameView.vue
+++ b/frontend/src/views/HallOfFameView.vue
@@ -85,9 +85,8 @@
           @page="onPage"
         />
       </TabPanel>
-      <TabPanel header="Career Stats">
+      <TabPanel header="Hitting Stats">
         <div v-if="hitters.length">
-          <h2>Hitters</h2>
           <table class="hof-table">
             <thead>
               <tr>
@@ -111,8 +110,9 @@
             </tbody>
           </table>
         </div>
+      </TabPanel>
+      <TabPanel header="Pitching Stats">
         <div v-if="pitchers.length">
-          <h2>Pitchers</h2>
           <table class="hof-table">
             <thead>
               <tr>


### PR DESCRIPTION
## Summary
- split Hall of Fame career stats into distinct Hitting Stats and Pitching Stats tabs

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c077e9a6a08326a056cad56eb81d21