### PR TITLE
feat: add standard and advanced HOF stats

### DIFF
--- a/frontend/src/views/HallOfFameView.test.js
+++ b/frontend/src/views/HallOfFameView.test.js
@@ -378,5 +378,72 @@ describe('HallOfFameView', () => {
     expect(rows).toHaveLength(1);
     expect(rows[0].text()).toContain('First0');
   });
+
+  it('renders standard and advanced stats tables for hitting and pitching', async () => {
+    fetchHallOfFamePlayers.mockResolvedValue({
+      players: [
+        {
+          bbref_id: 'p1',
+          name: 'Player One',
+          first_name: 'Player',
+          last_name: 'One',
+          position: 'Pitcher',
+          mlbam_id: '1',
+          year: 2000,
+          voted_by: 'BBWAA',
+        },
+      ],
+    });
+    fetchCareerStatsForPlayers.mockResolvedValue({
+      people: [
+        {
+          fullName: 'Player One',
+          stats: [
+            {
+              group: { displayName: 'hitting' },
+              type: { displayName: 'career' },
+              splits: [
+                {
+                  stat: {
+                    atBats: 10,
+                    hits: 4,
+                    plateAppearances: 12,
+                  },
+                },
+              ],
+            },
+            {
+              group: { displayName: 'pitching' },
+              type: { displayName: 'career' },
+              splits: [
+                {
+                  stat: {
+                    wins: 1,
+                    qualityStarts: 1,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const { default: HallOfFameView } = await import('./HallOfFameView.vue');
+    const wrapper = mount(HallOfFameView);
+    await flushPromises();
+
+    const hittingStandard = wrapper.find('[data-test="hitting-standard-table"]');
+    expect(hittingStandard.html()).toContain('AB');
+
+    const hittingAdvanced = wrapper.find('[data-test="hitting-advanced-table"]');
+    expect(hittingAdvanced.html()).toContain('PA');
+
+    const pitchingStandard = wrapper.find('[data-test="pitching-standard-table"]');
+    expect(pitchingStandard.html()).toContain('W');
+
+    const pitchingAdvanced = wrapper.find('[data-test="pitching-advanced-table"]');
+    expect(pitchingAdvanced.html()).toContain('QS');
+  });
 });
 

--- a/frontend/src/views/HallOfFameView.vue
+++ b/frontend/src/views/HallOfFameView.vue
@@ -86,56 +86,116 @@
         />
       </TabPanel>
       <TabPanel header="Hitting Stats">
-        <div v-if="hitters.length">
-          <table class="hof-table">
-            <thead>
-              <tr>
-                <th>#</th>
-                <th @click="sortHitters('name')">Name</th>
-                <th
-                  v-for="field in hittingFields"
-                  :key="field"
-                  @click="sortHitters(field)"
-                >
-                  {{ fieldLabels[field] ?? field }}
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="(h, index) in sortedHitters" :key="h.name">
-                <td>{{ index + 1 }}</td>
-                <td>{{ h.name }}</td>
-                <td v-for="field in hittingFields" :key="field">{{ h[field] ?? '-' }}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+        <TabView>
+          <TabPanel header="Standard">
+            <div v-if="hitters.length">
+              <table class="hof-table" data-test="hitting-standard-table">
+                <thead>
+                  <tr>
+                    <th>#</th>
+                    <th @click="sortHitters('name')">Name</th>
+                    <th
+                      v-for="field in hittingStandardFields"
+                      :key="field"
+                      @click="sortHitters(field)"
+                    >
+                      {{ fieldLabels[field] ?? field }}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="(h, index) in sortedHitters" :key="h.name">
+                    <td>{{ index + 1 }}</td>
+                    <td>{{ h.name }}</td>
+                    <td v-for="field in hittingStandardFields" :key="field">{{ h[field] ?? '-' }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </TabPanel>
+          <TabPanel header="Advanced">
+            <div v-if="hitters.length">
+              <table class="hof-table" data-test="hitting-advanced-table">
+                <thead>
+                  <tr>
+                    <th>#</th>
+                    <th @click="sortHitters('name')">Name</th>
+                    <th
+                      v-for="field in hittingAdvancedFields"
+                      :key="field"
+                      @click="sortHitters(field)"
+                    >
+                      {{ fieldLabels[field] ?? field }}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="(h, index) in sortedHitters" :key="h.name">
+                    <td>{{ index + 1 }}</td>
+                    <td>{{ h.name }}</td>
+                    <td v-for="field in hittingAdvancedFields" :key="field">{{ h[field] ?? '-' }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </TabPanel>
+        </TabView>
       </TabPanel>
       <TabPanel header="Pitching Stats">
-        <div v-if="pitchers.length">
-          <table class="hof-table">
-            <thead>
-              <tr>
-                <th>#</th>
-                <th @click="sortPitchers('name')">Name</th>
-                <th
-                  v-for="field in pitchingFields"
-                  :key="field"
-                  @click="sortPitchers(field)"
-                >
-                  {{ fieldLabels[field] ?? field }}
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="(p, index) in sortedPitchers" :key="p.name">
-                <td>{{ index + 1 }}</td>
-                <td>{{ p.name }}</td>
-                <td v-for="field in pitchingFields" :key="field">{{ p[field] ?? '-' }}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+        <TabView>
+          <TabPanel header="Standard">
+            <div v-if="pitchers.length">
+              <table class="hof-table" data-test="pitching-standard-table">
+                <thead>
+                  <tr>
+                    <th>#</th>
+                    <th @click="sortPitchers('name')">Name</th>
+                    <th
+                      v-for="field in pitchingStandardFields"
+                      :key="field"
+                      @click="sortPitchers(field)"
+                    >
+                      {{ fieldLabels[field] ?? field }}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="(p, index) in sortedPitchers" :key="p.name">
+                    <td>{{ index + 1 }}</td>
+                    <td>{{ p.name }}</td>
+                    <td v-for="field in pitchingStandardFields" :key="field">{{ p[field] ?? '-' }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </TabPanel>
+          <TabPanel header="Advanced">
+            <div v-if="pitchers.length">
+              <table class="hof-table" data-test="pitching-advanced-table">
+                <thead>
+                  <tr>
+                    <th>#</th>
+                    <th @click="sortPitchers('name')">Name</th>
+                    <th
+                      v-for="field in pitchingAdvancedFields"
+                      :key="field"
+                      @click="sortPitchers(field)"
+                    >
+                      {{ fieldLabels[field] ?? field }}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="(p, index) in sortedPitchers" :key="p.name">
+                    <td>{{ index + 1 }}</td>
+                    <td>{{ p.name }}</td>
+                    <td v-for="field in pitchingAdvancedFields" :key="field">{{ p[field] ?? '-' }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </TabPanel>
+        </TabView>
       </TabPanel>
     </TabView>
     <LoadingDialog :visible="loading" />
@@ -145,7 +205,13 @@
 <script setup>
 import { ref, onMounted, computed, watch } from 'vue';
 import { fetchHallOfFamePlayers, fetchCareerStatsForPlayers } from '../services/api';
-import { fieldLabels } from '../config/playerStatsConfig.js';
+import {
+  standardHittingFields,
+  advancedHittingFields,
+  standardPitchingFields,
+  advancedPitchingFields,
+  fieldLabels,
+} from '../config/playerStatsConfig.js';
 import logger from '../utils/logger';
 import LoadingDialog from '../components/LoadingDialog.vue';
 import Paginator from 'primevue/paginator';
@@ -166,9 +232,10 @@ const lastNameSearch = ref('');
 const first = ref(0);
 const rows = 50;
 
-
-const hittingFields = ['atBats', 'hits', 'homeRuns', 'rbi', 'avg', 'obp', 'slg', 'ops'];
-const pitchingFields = ['wins', 'losses', 'era', 'gamesPitched', 'gamesStarted', 'inningsPitched', 'strikeOuts', 'saves', 'whip'];
+const hittingStandardFields = standardHittingFields.filter((f) => f !== 'team');
+const hittingAdvancedFields = advancedHittingFields.filter((f) => f !== 'team');
+const pitchingStandardFields = standardPitchingFields.filter((f) => f !== 'team');
+const pitchingAdvancedFields = advancedPitchingFields.filter((f) => f !== 'team');
 
 const hittingSortKey = ref('name');
 const hittingSortAsc = ref(true);


### PR DESCRIPTION
## Summary
- add Standard/Advanced sub-tabs for hitting and pitching stats on the Hall of Fame page
- import standardized stat field lists and filter out team columns
- test rendering of new sub-tab tables

## Testing
- `npm -s test`


------
https://chatgpt.com/codex/tasks/task_e_68c09278ac4c8326adc06b894eff5b81