### PR TITLE
feat: display birthdates for hall of fame inductees

### DIFF
--- a/frontend/src/views/HallOfFameView.test.js
+++ b/frontend/src/views/HallOfFameView.test.js
@@ -52,7 +52,12 @@ describe('HallOfFameView', () => {
         },
       ],
     });
-    fetchCareerStatsForPlayers.mockResolvedValue({ people: [] });
+    fetchCareerStatsForPlayers.mockResolvedValue({
+      people: [
+        { id: 2, birthDate: '1980-02-02', stats: [] },
+        { id: 1, birthDate: '1990-01-01', stats: [] },
+      ],
+    });
 
     const { default: HallOfFameView } = await import('./HallOfFameView.vue');
     const wrapper = mount(HallOfFameView);
@@ -73,11 +78,12 @@ describe('HallOfFameView', () => {
     const cells = rows[0].findAll('td');
     expect(cells[0].text()).toBe('Alpha');
     expect(cells[1].text()).toBe('One');
-    expect(cells[2].text()).toBe('Shortstop');
-    expect(cells[4].text()).toBe('Veterans');
+    expect(cells[2].text()).toBe('1990-01-01');
+    expect(cells[3].text()).toBe('Shortstop');
+    expect(cells[5].text()).toBe('Veterans');
 
     // sort by year
-    await wrapper.findAll('th')[3].trigger('click');
+    await wrapper.findAll('th')[4].trigger('click');
     await flushPromises();
     const sortedRows = wrapper.findAll('tbody tr');
     expect(sortedRows[0].text()).toContain('Beta');
@@ -126,7 +132,7 @@ describe('HallOfFameView', () => {
     await flushPromises();
 
     // sort by year descending
-    const yearHeader = wrapper.findAll('th')[3];
+    const yearHeader = wrapper.findAll('th')[4];
     await yearHeader.trigger('click');
     await flushPromises();
     await yearHeader.trigger('click');
@@ -187,21 +193,21 @@ describe('HallOfFameView', () => {
     const headers = wrapper.findAll('th');
 
     // sort by year descending
-    await headers[3].trigger('click');
-    await headers[3].trigger('click');
+    await headers[4].trigger('click');
+    await headers[4].trigger('click');
     await flushPromises();
     let rows = wrapper.findAll('tbody tr');
     expect(rows[0].text()).toContain('Zed');
 
     // sort by year ascending
-    await headers[3].trigger('click');
+    await headers[4].trigger('click');
     await flushPromises();
     rows = wrapper.findAll('tbody tr');
     expect(rows[0].text()).toContain('Minnie');
 
     // sort by mlbam_id descending
-    await headers[5].trigger('click');
-    await headers[5].trigger('click');
+    await headers[6].trigger('click');
+    await headers[6].trigger('click');
     await flushPromises();
     rows = wrapper.findAll('tbody tr');
     expect(rows[0].text()).toContain('Zed');

--- a/frontend/src/views/HallOfFameView.vue
+++ b/frontend/src/views/HallOfFameView.vue
@@ -11,6 +11,7 @@
             <tr>
               <th @click="sortBy('first_name')">First Name</th>
               <th @click="sortBy('last_name')">Last Name</th>
+              <th @click="sortBy('birth_date')">Birthdate</th>
               <th @click="sortBy('position')">Position</th>
               <th @click="sortBy('year')">Year Inducted</th>
               <th @click="sortBy('voted_by')">Voted By</th>
@@ -26,6 +27,7 @@
                   data-test="last-name-search"
                 />
               </th>
+              <th></th>
               <th>
                 <select v-model="positionFilter" data-test="position-filter">
                   <option value="">All</option>
@@ -61,6 +63,7 @@
             <tr v-for="player in paginatedPlayers" :key="player.bbref_id">
               <td>{{ player.first_name }}</td>
               <td>{{ player.last_name }}</td>
+              <td>{{ player.birth_date }}</td>
               <td>{{ player.position }}</td>
               <td>{{ player.year }}</td>
               <td>{{ player.voted_by }}</td>
@@ -319,15 +322,24 @@ async function loadCareerStats() {
     const data = await fetchCareerStatsForPlayers(ids);
     const hit = [];
     const pitch = [];
+    const birthdates = new Map();
     for (const person of data?.people || []) {
       const name = person.fullName || `${person.firstName ?? ''} ${person.lastName ?? ''}`.trim();
       const h = findGroup(person, 'hitting', 'career')?.splits?.[0]?.stat;
       const pc = findGroup(person, 'pitching', 'career')?.splits?.[0]?.stat;
       if (h) hit.push({ name, ...h });
       if (pc) pitch.push({ name, ...pc });
+      if (person.id && person.birthDate) {
+        birthdates.set(Number(person.id), person.birthDate);
+      }
     }
     hitters.value = hit;
     pitchers.value = pitch;
+    for (const p of players.value) {
+      if (p.mlbam_id) {
+        p.birth_date = birthdates.get(p.mlbam_id) || null;
+      }
+    }
   } catch (err) {
     logger.error('Failed to fetch career stats', err);
   }


### PR DESCRIPTION
## Summary
- show players' birthdates in the Hall of Fame inductees table
- populate birthdates from MLB career stats
- update Hall of Fame view tests for new column

## Testing
- `npm test` *(fails: npm not installed)*
- `pytest` *(fails: 17 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c0932a83e08326896a5d56de441f33