### PR TITLE
feat: add batting spray chart

### DIFF
--- a/frontend/src/components/BatterSprayChart.vue
+++ b/frontend/src/components/BatterSprayChart.vue
@@ -14,68 +14,124 @@
 <script setup>
 import { ref, onMounted, onBeforeUnmount } from 'vue';
 import Chart from 'chart.js/auto';
-import diamond from '../assets/diamond.svg';
 
 const battedBallsCanvas = ref(null);
 const hitsCanvas = ref(null);
 let battedBallsChart;
 let hitsChart;
-
-const sprayData = [
-  { x: -30, y: 80, result: 'out' },
-  { x: 20, y: 70, result: 'single' },
-  { x: -60, y: 110, result: 'double' },
-  { x: 50, y: 90, result: 'triple' },
-  { x: 0, y: 120, result: 'home_run' },
-  { x: 30, y: 60, result: 'out' },
-  { x: -20, y: 95, result: 'single' },
-  { x: 70, y: 130, result: 'home_run' },
-  { x: -90, y: 140, result: 'double' },
-  { x: 10, y: 50, result: 'out' }
+// Sample Statcast-style data (hc_x/hc_y are Statcast coordinates)
+const statcastData = [
+  { hc_x: 95.42, hc_y: 118.27, events: 'field_out' },
+  { hc_x: 145.42, hc_y: 128.27, events: 'single' },
+  { hc_x: 65.42, hc_y: 88.27, events: 'double' },
+  { hc_x: 175.42, hc_y: 108.27, events: 'triple' },
+  { hc_x: 125.42, hc_y: 78.27, events: 'home_run' },
+  { hc_x: 155.42, hc_y: 138.27, events: 'field_out' },
+  { hc_x: 105.42, hc_y: 103.27, events: 'single' },
+  { hc_x: 195.42, hc_y: 68.27, events: 'home_run' },
+  { hc_x: 35.42, hc_y: 58.27, events: 'double' },
+  { hc_x: 135.42, hc_y: 148.27, events: 'field_out' }
 ];
 
-const hitsData = sprayData.filter(p => p.result !== 'out');
+// Batted-ball and hit events from baseball_data_lab constants
+const battedBallEvents = [
+  'single',
+  'double',
+  'triple',
+  'home_run',
+  'field_out',
+  'grounded_into_double_play',
+  'force_out',
+  'sac_fly',
+  'sac_bunt',
+  'field_error',
+  'double_play',
+  'triple_play',
+  'catcher_interf',
+  'fielders_choice'
+];
 
-const colors = {
-  single: '#1f77b4',
-  double: '#2ca02c',
-  triple: '#ff7f0e',
-  home_run: '#d62728',
-  out: '#666666'
-};
+const hitEvents = ['single', 'double', 'triple', 'home_run'];
 
-const labels = {
-  single: 'Single',
-  double: 'Double',
-  triple: 'Triple',
-  home_run: 'Home Run',
-  out: 'Out'
+// Transform Statcast coordinates similar to the BattingSprayChart class
+function transformStatcast(data) {
+  return data
+    .filter(d => battedBallEvents.includes(d.events) && d.hc_x != null && d.hc_y != null)
+    .map(d => ({
+      x: d.hc_x - 125.42,
+      y: 198.27 - d.hc_y,
+      result: d.events
+    }));
+}
+
+const sprayData = transformStatcast(statcastData);
+const hitsData = sprayData.filter(p => hitEvents.includes(p.result));
+
+// Styling for different events
+const eventStyles = {
+  single: { color: '#1f77b4', label: 'Single' },
+  double: { color: '#2ca02c', label: 'Double' },
+  triple: { color: '#ff7f0e', label: 'Triple' },
+  home_run: { color: '#d62728', label: 'Home Run' }
 };
+const outStyle = { color: '#666666', label: 'Out' };
 
 function buildDatasets(points) {
   const grouped = {};
   points.forEach(pt => {
-    if (!grouped[pt.result]) grouped[pt.result] = [];
-    grouped[pt.result].push({ x: pt.x, y: pt.y });
+    const key = eventStyles[pt.result] ? pt.result : 'out';
+    if (!grouped[key]) grouped[key] = [];
+    grouped[key].push({ x: pt.x, y: pt.y });
   });
-  return Object.keys(grouped).map(result => ({
-    label: labels[result],
-    data: grouped[result],
-    backgroundColor: colors[result]
-  }));
+  return Object.keys(grouped).map(result => {
+    const style = eventStyles[result] || outStyle;
+    return {
+      label: style.label,
+      data: grouped[result],
+      backgroundColor: style.color
+    };
+  });
 }
 
-const fieldImage = new Image();
-fieldImage.src = diamond;
-const fieldPlugin = {
-  id: 'diamondBackground',
-  beforeDraw(chart) {
-    const { ctx, chartArea: { left, top, width, height } } = chart;
-    if (fieldImage.complete) {
-      ctx.drawImage(fieldImage, left, top, width, height);
-    } else {
-      fieldImage.onload = () => chart.draw();
+// Compute scale bounds based on data, similar to the Python implementation
+function scaleBounds(data) {
+  const xs = data.map(p => p.x);
+  const ys = data.map(p => p.y);
+  return {
+    x: { min: Math.min(...xs) - 10, max: Math.max(...xs) + 10 },
+    // Ensure home plate (0,0) is at the bottom of the chart
+    y: {
+      min: Math.min(...ys) > 0 ? 0 : Math.min(...ys) - 10,
+      max: Math.max(...ys) + 10
     }
+  };
+}
+
+const bounds = scaleBounds(sprayData);
+
+// Plugin to draw the diamond baselines using Chart.js
+const diamondPlugin = {
+  id: 'diamondPlugin',
+  afterDraw(chart) {
+    const { ctx, scales: { x, y } } = chart;
+    const diamondSize = (x.max - x.min) * 0.2;
+    const home = { x: 0, y: 0 };
+    const first = { x: diamondSize, y: diamondSize };
+    const third = { x: -diamondSize, y: diamondSize };
+    const second = { x: 0, y: diamondSize * 2 };
+
+    ctx.save();
+    ctx.strokeStyle = '#d3d3d3';
+    ctx.beginPath();
+    ctx.moveTo(x.getPixelForValue(home.x), y.getPixelForValue(home.y));
+    ctx.lineTo(x.getPixelForValue(first.x), y.getPixelForValue(first.y));
+    ctx.moveTo(x.getPixelForValue(home.x), y.getPixelForValue(home.y));
+    ctx.lineTo(x.getPixelForValue(third.x), y.getPixelForValue(third.y));
+    ctx.moveTo(x.getPixelForValue(first.x), y.getPixelForValue(first.y));
+    ctx.lineTo(x.getPixelForValue(second.x), y.getPixelForValue(second.y));
+    ctx.lineTo(x.getPixelForValue(third.x), y.getPixelForValue(third.y));
+    ctx.stroke();
+    ctx.restore();
   }
 };
 
@@ -90,12 +146,9 @@ function createChart(canvas, data) {
           position: 'bottom'
         }
       },
-      scales: {
-        x: { min: -150, max: 150 },
-        y: { min: 0, max: 150 }
-      }
+      scales: bounds
     },
-    plugins: [fieldPlugin]
+    plugins: [diamondPlugin]
   });
 }
 


### PR DESCRIPTION
## Summary
- implement Chart.js batting spray chart with Statcast coordinate transform
- draw field baselines with custom plugin
- ensure spray chart scale includes home plate at bottom

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c102f5b3a88326965c9c4b43e7e6f6